### PR TITLE
[P1.1] imp.py — entry point and server launch

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,17 @@
+# Imp runtime state
+.imp/
+
+# Python
+__pycache__/
+*.py[cod]
+*$py.class
+*.egg-info/
+.venv/
+venv/
+
+# macOS
+.DS_Store
+
+# Editors
+.vscode/
+.idea/

--- a/imp.py
+++ b/imp.py
@@ -1,26 +1,36 @@
 #!/usr/bin/env python3
 """Imp — entry point.
 
-Starts the Imp web service. The terminal does only:
+Starts the Imp web service.
 
-  1. Check Python version
-  2. Verify required Python packages are installed; offer to install if missing
-  3. Start uvicorn against `server.app:app`
-  4. Print the URL
+  1. Bootstrap a project-local virtual environment at .venv/ on first run,
+     then re-exec inside it so the rest of the script runs against private
+     dependencies.
+  2. Install any missing required packages into the private venv. No prompt:
+     the venv is private to this project so there's nothing to ask permission
+     about.
+  3. Start uvicorn against `server.app:app`.
+  4. Print the URL.
 
 After this, the terminal only shows logs. All further configuration happens
 in the browser via the Setup Agent.
+
+Set ``IMP_USE_SYSTEM_PYTHON=1`` to skip the venv bootstrap and use the active
+interpreter — for Docker images and similar environments where Python is
+already managed externally.
 """
 
 from __future__ import annotations
 
-import importlib.util
+import os
+import shutil
 import subprocess
 import sys
 from pathlib import Path
 
 REQUIRED_PYTHON = (3, 11)
 ROOT = Path(__file__).resolve().parent
+VENV_DIR = ROOT / ".venv"
 REQUIREMENTS_FILE = ROOT / "requirements.txt"
 STATE_DIR = ROOT / ".imp"
 HOST = "127.0.0.1"
@@ -41,6 +51,70 @@ def check_python_version() -> None:
         sys.exit(1)
 
 
+# ---------- venv bootstrap ----------
+
+def venv_python() -> Path:
+    if sys.platform == "win32":
+        return VENV_DIR / "Scripts" / "python.exe"
+    return VENV_DIR / "bin" / "python"
+
+
+def in_our_venv() -> bool:
+    return Path(sys.prefix).resolve() == VENV_DIR
+
+
+def venv_is_healthy() -> bool:
+    py = venv_python()
+    if not py.exists():
+        return False
+    result = subprocess.run(
+        [str(py), "-c", "import sys"],
+        capture_output=True,
+    )
+    return result.returncode == 0
+
+
+def bootstrap_venv() -> None:
+    """Create .venv/ if missing and re-exec inside it.
+
+    No-op if IMP_USE_SYSTEM_PYTHON=1 or if we are already running inside
+    our own venv. After re-exec, the new process re-enters this function,
+    sees ``in_our_venv()`` is True, and returns immediately.
+    """
+    if os.environ.get("IMP_USE_SYSTEM_PYTHON") == "1":
+        if Path(sys.prefix) == Path(sys.base_prefix):
+            print(
+                "Warning: IMP_USE_SYSTEM_PYTHON=1 set but no venv active. "
+                "pip will install into the system Python.",
+                flush=True,
+            )
+        return
+
+    if in_our_venv():
+        return
+
+    if VENV_DIR.exists() and not venv_is_healthy():
+        print("Existing .venv/ looks broken; recreating.", flush=True)
+        shutil.rmtree(VENV_DIR)
+
+    if not VENV_DIR.exists():
+        print("Creating .venv/ (one-time setup)...", flush=True)
+        import venv
+
+        venv.create(VENV_DIR, with_pip=True)
+
+    # Force unbuffered stdout in the re-exec'd process so its log lines stay
+    # interleaved correctly with subprocess output (pip, uvicorn).
+    os.environ["PYTHONUNBUFFERED"] = "1"
+
+    # Re-exec inside our venv. os.execv replaces the current process, so the
+    # user sees one continuous run with no second prompt.
+    py = venv_python()
+    os.execv(str(py), [str(py), str(Path(__file__).resolve()), *sys.argv[1:]])
+
+
+# ---------- dependency management ----------
+
 def read_requirements() -> list[str]:
     """Return pip package names from requirements.txt, version specifiers stripped."""
     if not REQUIREMENTS_FILE.exists():
@@ -60,6 +134,8 @@ def read_requirements() -> list[str]:
 
 
 def find_missing(packages: list[str]) -> list[str]:
+    import importlib.util
+
     missing: list[str] = []
     for pkg in packages:
         import_name = IMPORT_NAME_OVERRIDES.get(pkg, pkg.replace("-", "_"))
@@ -69,45 +145,37 @@ def find_missing(packages: list[str]) -> list[str]:
 
 
 def install(packages: list[str]) -> None:
-    print(f"\nInstalling: {', '.join(packages)}\n")
+    print(f"Installing: {', '.join(packages)}", flush=True)
     result = subprocess.run(
-        [sys.executable, "-m", "pip", "install", *packages],
+        [sys.executable, "-m", "pip", "install", "--quiet", *packages],
         check=False,
     )
     if result.returncode != 0:
-        print("\npip install failed. Fix the error above and re-run.")
+        print("\npip install failed. Fix the error above and re-run.", flush=True)
         sys.exit(1)
 
 
 def ensure_dependencies() -> None:
     packages = read_requirements()
     missing = find_missing(packages)
-    if not missing:
-        return
-    print("Imp needs the following Python packages:")
-    for pkg in missing:
-        print(f"  - {pkg}")
-    try:
-        answer = input("Install these? [y/n] ").strip().lower()
-    except EOFError:
-        answer = ""
-    if answer not in ("y", "yes"):
-        print("Cannot start without required packages. Exiting.")
-        sys.exit(1)
-    install(missing)
+    if missing:
+        install(missing)
 
+
+# ---------- server launch ----------
 
 def start_server() -> None:
-    # Imported lazily so the dependency check above runs first.
+    # Imported lazily so dependency installation runs first.
     import uvicorn
 
-    print(f"\nImp listening on http://{HOST}:{PORT}")
-    print("Open in your browser to talk to Foreman. Ctrl+C to stop.\n")
+    print(f"\nImp listening on http://{HOST}:{PORT}", flush=True)
+    print("Open in your browser to talk to Foreman. Ctrl+C to stop.\n", flush=True)
     uvicorn.run("server.app:app", host=HOST, port=PORT, log_level="info")
 
 
 def main() -> None:
     check_python_version()
+    bootstrap_venv()
     ensure_dependencies()
     STATE_DIR.mkdir(exist_ok=True)
     start_server()

--- a/imp.py
+++ b/imp.py
@@ -1,0 +1,117 @@
+#!/usr/bin/env python3
+"""Imp — entry point.
+
+Starts the Imp web service. The terminal does only:
+
+  1. Check Python version
+  2. Verify required Python packages are installed; offer to install if missing
+  3. Start uvicorn against `server.app:app`
+  4. Print the URL
+
+After this, the terminal only shows logs. All further configuration happens
+in the browser via the Setup Agent.
+"""
+
+from __future__ import annotations
+
+import importlib.util
+import subprocess
+import sys
+from pathlib import Path
+
+REQUIRED_PYTHON = (3, 11)
+ROOT = Path(__file__).resolve().parent
+REQUIREMENTS_FILE = ROOT / "requirements.txt"
+STATE_DIR = ROOT / ".imp"
+HOST = "127.0.0.1"
+PORT = 8420
+
+# Pip package name → import name (only when they differ)
+IMPORT_NAME_OVERRIDES = {
+    "claude-agent-sdk": "claude_agent_sdk",
+    "argon2-cffi": "argon2",
+}
+
+
+def check_python_version() -> None:
+    if sys.version_info < REQUIRED_PYTHON:
+        major, minor = REQUIRED_PYTHON
+        have = ".".join(str(p) for p in sys.version_info[:3])
+        print(f"Imp requires Python {major}.{minor}+. You have {have}.")
+        sys.exit(1)
+
+
+def read_requirements() -> list[str]:
+    """Return pip package names from requirements.txt, version specifiers stripped."""
+    if not REQUIREMENTS_FILE.exists():
+        print(f"Missing {REQUIREMENTS_FILE.name}. Cannot determine required packages.")
+        sys.exit(1)
+    packages: list[str] = []
+    for raw in REQUIREMENTS_FILE.read_text().splitlines():
+        line = raw.split("#", 1)[0].strip()
+        if not line:
+            continue
+        for sep in ("==", ">=", "<=", "~=", "!=", ">", "<"):
+            if sep in line:
+                line = line.split(sep, 1)[0].strip()
+                break
+        packages.append(line)
+    return packages
+
+
+def find_missing(packages: list[str]) -> list[str]:
+    missing: list[str] = []
+    for pkg in packages:
+        import_name = IMPORT_NAME_OVERRIDES.get(pkg, pkg.replace("-", "_"))
+        if importlib.util.find_spec(import_name) is None:
+            missing.append(pkg)
+    return missing
+
+
+def install(packages: list[str]) -> None:
+    print(f"\nInstalling: {', '.join(packages)}\n")
+    result = subprocess.run(
+        [sys.executable, "-m", "pip", "install", *packages],
+        check=False,
+    )
+    if result.returncode != 0:
+        print("\npip install failed. Fix the error above and re-run.")
+        sys.exit(1)
+
+
+def ensure_dependencies() -> None:
+    packages = read_requirements()
+    missing = find_missing(packages)
+    if not missing:
+        return
+    print("Imp needs the following Python packages:")
+    for pkg in missing:
+        print(f"  - {pkg}")
+    try:
+        answer = input("Install these? [y/n] ").strip().lower()
+    except EOFError:
+        answer = ""
+    if answer not in ("y", "yes"):
+        print("Cannot start without required packages. Exiting.")
+        sys.exit(1)
+    install(missing)
+
+
+def start_server() -> None:
+    # Imported lazily so the dependency check above runs first.
+    import uvicorn
+
+    print(f"\nImp listening on http://{HOST}:{PORT}")
+    print("Open in your browser to talk to Foreman. Ctrl+C to stop.\n")
+    uvicorn.run("server.app:app", host=HOST, port=PORT, log_level="info")
+
+
+def main() -> None:
+    check_python_version()
+    ensure_dependencies()
+    STATE_DIR.mkdir(exist_ok=True)
+    start_server()
+
+
+if __name__ == "__main__":
+    main()

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,0 +1,6 @@
+fastapi
+uvicorn
+websockets
+claude-agent-sdk
+argon2-cffi
+itsdangerous

--- a/server/app.py
+++ b/server/app.py
@@ -1,0 +1,22 @@
+"""Stub FastAPI app for [P1.1].
+
+This is a placeholder so `uvicorn server.app:app` can start during P1.1.
+The real app — login, chat, WebSocket, setup routing — is delivered in:
+
+  - KKallas/Imp#2  P1.2 server/auth.py
+  - KKallas/Imp#3  P1.3 server/app.py (this file, rewritten)
+  - KKallas/Imp#4  P1.4 ui/index.html + app.js
+  - KKallas/Imp#5  P1.5 ui/renderers/markdown.js
+"""
+
+from fastapi import FastAPI
+
+app = FastAPI(title="Imp (P1.1 stub)")
+
+
+@app.get("/")
+def root() -> dict[str, str]:
+    return {
+        "status": "ok",
+        "message": "Imp is running. The real UI lands in P1.3+ (KKallas/Imp#3).",
+    }


### PR DESCRIPTION
Closes KKallas/Imp#1.

## Summary

Adds the Python entry point `imp.py`, a minimal `requirements.txt`, and a stub `server/app.py` so the chain `python imp.py` → uvicorn → HTTP request actually works end-to-end. **Auto-bootstraps a project-local `.venv/` on first run** so the user never has to manage a venv themselves and the script can run unattended on a VPS without a TTY.

## Files

| File | Purpose |
|---|---|
| `imp.py` | Entry point: Python version check → venv bootstrap + re-exec → silent dep install → start uvicorn → print URL |
| `requirements.txt` | fastapi, uvicorn, websockets, claude-agent-sdk, argon2-cffi, itsdangerous |
| `server/__init__.py` | Empty package marker |
| `server/app.py` | **Stub** FastAPI app — placeholder so uvicorn can start. Replaced by real app in KKallas/Imp#3 |
| `.gitignore` | `.venv/`, `.imp/`, `__pycache__/`, `.DS_Store`, editor dirs |

## Auto-venv design

`imp.py` manages its own virtual environment at `.venv/` in the project root. On first run it creates the venv with `venv.create(with_pip=True)`, then re-execs itself (`os.execv`) inside the new interpreter so the rest of the script runs against private dependencies. On subsequent runs the bootstrap is a no-op — the script is already inside `.venv/`.

Edge cases handled:
- **Corrupted venv** (missing or non-runnable `python`): detected via `venv_is_healthy()` and the venv is recreated.
- **Power-user escape hatch**: `IMP_USE_SYSTEM_PYTHON=1` skips the bootstrap entirely (for Docker images and environments where Python is managed externally). A warning is printed if no venv is active in that case.
- **Log buffering**: forces `PYTHONUNBUFFERED=1` for the re-exec'd process and uses `flush=True` on all `print()` calls so log lines interleave correctly with subprocess output (pip, uvicorn).

## Verification

Tested in two states on macOS / Python 3.12.8:

**Clean state** (`rm -rf .venv`, fresh boot, no TTY):
```
$ python3 imp.py < /dev/null
Creating .venv/ (one-time setup)...
Installing: fastapi, uvicorn, websockets, claude-agent-sdk, argon2-cffi, itsdangerous

Imp listening on http://127.0.0.1:8420
Open in your browser to talk to Foreman. Ctrl+C to stop.

INFO:     Started server process [50734]
INFO:     Application startup complete.
INFO:     Uvicorn running on http://127.0.0.1:8420 (Press CTRL+C to quit)
INFO:     127.0.0.1:56726 - "GET / HTTP/1.1" 200 OK
```

**Warm state** (`.venv/` already exists with deps):
```
$ python3 imp.py < /dev/null
Imp listening on http://127.0.0.1:8420
Open in your browser to talk to Foreman. Ctrl+C to stop.
INFO:     Started server process [50853]
...
INFO:     127.0.0.1:56819 - "GET / HTTP/1.1" 200 OK
```

Both runs use `< /dev/null` so the no-TTY (VPS systemd) path is exercised. `curl http://127.0.0.1:8420/` returns 200 OK with the stub payload in both cases.

## Issues found while implementing this — for the v0.1 spec discussion

This PR is also a probe of the issue itself. Some of the original findings dissolved when the auto-venv landed; the rest stand and need decisions before later issues can land cleanly.

### Resolved by this PR

- ~~**System Python pollution**~~ — `.venv/` is private, no host interpreter is touched.
- ~~**VPS / no-TTY tension**~~ — there is no `input()` prompt to deadlock on. `< /dev/null` works.
- ~~**Venv documentation gap**~~ — nothing for the user to document; the venv is automatic.

### Still open

1. **P1.1's acceptance criteria implicitly require P1.3.** "`python imp.py` reaches 'server listening on …'" cannot pass without `server.app:app` existing. I ship a stub `server/app.py` so the criterion is meetable in isolation, but this means P1.1 silently produces a P1.3 deliverable. **Recommendation:** add to KKallas/Imp#3's acceptance criteria: "replaces the stub `server/app.py` from P1.1, not extends it."

2. **`claude-agent-sdk` is at v0.1.58 (early/unstable).** The package exists on PyPI but the version number signals API churn. **Recommendation:** decide on a pinning strategy before KKallas/Imp#11 (foreman_agent.py) is built against it. Either pin in requirements.txt for reproducibility, or document explicitly that the project tracks latest and accepts breakage.

3. **Host/port hardcoded in imp.py.** v0.1.md says "default 127.0.0.1:8420, override via config when fronted by reverse proxy." My imp.py has both as constants. Config-driven host/port lands properly once `.imp/config.json` exists (after KKallas/Imp#2). **Recommendation:** add to KKallas/Imp#2 or KKallas/Imp#3 acceptance criteria: "imp.py reads host/port from .imp/config.json if present."

4. **No test coverage strategy for the entry point.** v0.1.md's Testing section is about pipeline scripts. There's no policy for testing imp.py / server/app.py / server/auth.py. **Recommendation:** decide before phase 2 (the security spine), where tests genuinely matter.

5. **`argon2-cffi` is in requirements.txt** even though P1.1 doesn't use it — it's needed by P1.2. Pulling it in early avoids a second dep-check round trip mid-phase, but requirements.txt is ahead of the code. **Recommendation:** make this a project rule one way or the other ("requirements.txt is the union of all phases" vs "each phase only adds what it uses").

6. **Python version drift between runs.** If the user upgrades from 3.11 to 3.12, the venv may be subtly broken (works for me, but technically the venv was created against the old binary). Currently I only check `venv_is_healthy()` (does the binary exist + run). Stricter would be: store the host Python version inside `.venv/.imp_python_version` and recreate if it changed. **Acceptable as-is for v0.1**, noting for the record.

## Test plan

- [x] Clean run on macOS Python 3.12 with no TTY → bootstraps, installs, starts, curl 200
- [x] Warm run with existing `.venv/` → silent start, curl 200, ~1s to ready
- [ ] Run on Linux (any distro) — sanity check that `os.execv` and venv layout work as expected
- [ ] Run with `IMP_USE_SYSTEM_PYTHON=1` from inside an existing venv to verify the escape hatch
- [ ] Decide on items 1, 2, 3, 4, 5 above before merging — they affect downstream issues