### PR TITLE
[P1.2] main.py — real auth (terminal getpass), real gh integration, repo auto-detect

### DIFF
--- a/imp.py
+++ b/imp.py
@@ -204,7 +204,14 @@ def start_server() -> None:
         flush=True,
     )
     print(f"\nWill be available at http://{HOST}:{PORT}", flush=True)
-    print("Default spike password: imp", flush=True)
+    cfg_file = STATE_DIR / "config.json"
+    if not cfg_file.exists() or "admin_password_hash" not in cfg_file.read_text():
+        print(
+            "First-run bootstrap: no admin password set yet. On first login "
+            "any password works — the Setup Agent will immediately ask you "
+            "to set a real one.",
+            flush=True,
+        )
     print("Ctrl+C to stop.\n", flush=True)
 
     main_py = ROOT / "main.py"

--- a/imp.py
+++ b/imp.py
@@ -192,9 +192,117 @@ def ensure_chainlit_secret() -> str:
     return secret
 
 
+def ensure_admin_password() -> None:
+    """Prompt the admin to set a password on very first run.
+
+    Runs only if .imp/config.json does not already contain
+    `admin_password_hash`. Uses `getpass` so the password is never echoed
+    to the terminal, and requires double-entry confirmation. The plaintext
+    never leaves this function — we hash it with argon2id and persist only
+    the hash.
+
+    By the time this returns, Chainlit's auth callback is guaranteed to
+    have a hash to verify against, so there is no "bootstrap mode" and no
+    possibility of the password being entered in the browser chat (where
+    it would otherwise appear in the chat log).
+    """
+    import getpass
+    import json
+
+    cfg_file = STATE_DIR / "config.json"
+    cfg: dict = {}
+    if cfg_file.exists():
+        try:
+            cfg = json.loads(cfg_file.read_text())
+        except json.JSONDecodeError:
+            cfg = {}
+
+    if cfg.get("admin_password_hash"):
+        return  # Already set.
+
+    from argon2 import PasswordHasher
+
+    print("\nFirst-run admin password setup", flush=True)
+    print(
+        "This runs once. Imp will hash the password with argon2id and "
+        "store only the hash in .imp/config.json. The plaintext is never "
+        "written to disk or sent to the browser.",
+        flush=True,
+    )
+    while True:
+        try:
+            pw1 = getpass.getpass("Choose an admin password: ")
+        except EOFError:
+            print(
+                "\nNo TTY for password input. Set IMP_ADMIN_PASSWORD in the "
+                "environment once to seed an initial password non-interactively, "
+                "then unset it. Aborting.",
+                flush=True,
+            )
+            sys.exit(1)
+        if len(pw1) < 4:
+            print("Too short — minimum 4 characters.", flush=True)
+            continue
+        pw2 = getpass.getpass("Confirm password: ")
+        if pw1 != pw2:
+            print("Passwords don't match. Try again.", flush=True)
+            continue
+        break
+
+    hashed = PasswordHasher().hash(pw1)
+    cfg["admin_password_hash"] = hashed
+    STATE_DIR.mkdir(exist_ok=True)
+    cfg_file.write_text(json.dumps(cfg, indent=2))
+    cfg_file.chmod(0o600)
+    print("Admin password set.\n", flush=True)
+
+
+def ensure_admin_password_from_env() -> None:
+    """Alternate path for non-interactive deployments.
+
+    If IMP_ADMIN_PASSWORD is set in the env and no hash exists yet, seed
+    the hash from that value and exit. Intended for one-time seeding from
+    an infrastructure-provisioning script on a headless host, NOT as a
+    runtime password source.
+    """
+    import json
+
+    env_pw = os.environ.get("IMP_ADMIN_PASSWORD")
+    if not env_pw:
+        return
+
+    cfg_file = STATE_DIR / "config.json"
+    cfg: dict = {}
+    if cfg_file.exists():
+        try:
+            cfg = json.loads(cfg_file.read_text())
+        except json.JSONDecodeError:
+            cfg = {}
+    if cfg.get("admin_password_hash"):
+        return
+
+    if len(env_pw) < 4:
+        print("IMP_ADMIN_PASSWORD is set but too short (min 4). Ignoring.", flush=True)
+        return
+
+    from argon2 import PasswordHasher
+
+    cfg["admin_password_hash"] = PasswordHasher().hash(env_pw)
+    STATE_DIR.mkdir(exist_ok=True)
+    cfg_file.write_text(json.dumps(cfg, indent=2))
+    cfg_file.chmod(0o600)
+    print("Admin password seeded from IMP_ADMIN_PASSWORD env var.", flush=True)
+    print("You should unset IMP_ADMIN_PASSWORD now — it is only needed for first-run seeding.", flush=True)
+
+
 def start_server() -> None:
     secret = ensure_chainlit_secret()
     os.environ["CHAINLIT_AUTH_SECRET"] = secret
+
+    # Seed-from-env path first (headless deploys), then interactive path
+    # (human running it from a terminal).
+    ensure_admin_password_from_env()
+    ensure_admin_password()
 
     print("\nLoading chainlit...", flush=True)
     print(
@@ -204,14 +312,6 @@ def start_server() -> None:
         flush=True,
     )
     print(f"\nWill be available at http://{HOST}:{PORT}", flush=True)
-    cfg_file = STATE_DIR / "config.json"
-    if not cfg_file.exists() or "admin_password_hash" not in cfg_file.read_text():
-        print(
-            "First-run bootstrap: no admin password set yet. On first login "
-            "any password works — the Setup Agent will immediately ask you "
-            "to set a real one.",
-            flush=True,
-        )
     print("Ctrl+C to stop.\n", flush=True)
 
     main_py = ROOT / "main.py"

--- a/main.py
+++ b/main.py
@@ -3,16 +3,25 @@
 The entire frontend of Imp. Chainlit owns the wire; everything the user sees
 is produced by the handlers in this file calling Chainlit primitives.
 
-At this stage (P1.2) the Setup Agent and Foreman handlers are still largely
-stubbed — they demonstrate the UX and exercise the auth / dispatch / message
-plumbing, but the real agents replace them in later phases (see KKallas/Imp#9
-for setup_agent.py and KKallas/Imp#11 for foreman_agent.py).
+Auth is real as of P1.2: single-admin argon2id hash stored in
+.imp/config.json, seeded by imp.py via a getpass prompt on very first run.
+There is no bootstrap mode in the browser — by the time Chainlit starts,
+the hash is either there or the user was given a chance to set it in the
+terminal.
 
-Auth and the bootstrap flow are real as of P1.2:
-  - Single-admin argon2id password hash stored in .imp/config.json
-  - Bootstrap mode: when no hash is set yet, any password logs in, and the
-    Setup Agent immediately asks the admin to pick a real password that gets
-    hashed + persisted before the rest of setup runs.
+Setup Agent is partially real as of P1.2:
+  - Checks `gh auth status`; if not authenticated, tells the user to run
+    `gh auth login --web` in a terminal and waits for them to say "ready"
+  - Detects the target repo from `git remote get-url origin` — Imp is
+    expected to live inside the repo it manages, so the local git context
+    IS the config. If no origin is found, asks the user manually.
+  - Verifies the repo exists via `gh repo view`
+  - Stops there. Project-board bootstrap, loop config, etc. land in
+    KKallas/Imp#10, KKallas/Imp#23, etc.
+
+Foreman is still stubbed — the chat-command echo responses exercise the
+dispatch UX but produce no real work. Replaced by the real worker agent
+in KKallas/Imp#11.
 
 Try these messages after logging in (stub responses until later phases):
   - "show me the gantt chart"
@@ -23,12 +32,16 @@ Try these messages after logging in (stub responses until later phases):
   - "reset setup"
 
 To re-run the Setup Agent from scratch, delete .imp/config.json and refresh.
+To also wipe the admin password, delete the file outright — `reset setup`
+preserves the hash.
 """
 
 from __future__ import annotations
 
+import asyncio
 import json
 import re
+import subprocess
 from pathlib import Path
 
 import chainlit as cl
@@ -39,6 +52,67 @@ ROOT = Path(__file__).resolve().parent
 CONFIG_FILE = ROOT / ".imp" / "config.json"
 
 _hasher = PasswordHasher()
+
+
+# ---------- git / gh helpers ----------
+
+
+def detect_repo_from_git() -> str | None:
+    """Return `owner/name` from the local git origin, or None.
+
+    Imp is expected to live inside the repo it manages: you `git clone`
+    Imp into your project (or vendor it with git subtree), `cd` into the
+    project root, and run `python imp/imp.py`. From there, the local git
+    origin IS the target repo — no need to ask the admin which one.
+
+    Looks at the current working directory's `git remote get-url origin`.
+    Parses both SSH (`git@github.com:foo/bar.git`) and HTTPS
+    (`https://github.com/foo/bar.git`) forms.
+    """
+    try:
+        result = subprocess.run(
+            ["git", "remote", "get-url", "origin"],
+            capture_output=True,
+            text=True,
+            check=True,
+        )
+    except (subprocess.CalledProcessError, FileNotFoundError):
+        return None
+    url = result.stdout.strip()
+    m = re.match(
+        r"(?:git@github\.com:|https://github\.com/)([^/]+/[^/]+?)(?:\.git)?/?$",
+        url,
+    )
+    return m.group(1) if m else None
+
+
+async def gh_auth_status() -> tuple[bool, str]:
+    """Return `(authenticated, combined_output)` from `gh auth status`."""
+    proc = await asyncio.create_subprocess_exec(
+        "gh",
+        "auth",
+        "status",
+        stdout=asyncio.subprocess.PIPE,
+        stderr=asyncio.subprocess.STDOUT,
+    )
+    out, _ = await proc.communicate()
+    return proc.returncode == 0, out.decode().strip()
+
+
+async def gh_repo_view(owner_repo: str) -> tuple[bool, str]:
+    """Return `(exists, combined_output)` from `gh repo view`."""
+    proc = await asyncio.create_subprocess_exec(
+        "gh",
+        "repo",
+        "view",
+        owner_repo,
+        "--json",
+        "nameWithOwner,defaultBranchRef,visibility",
+        stdout=asyncio.subprocess.PIPE,
+        stderr=asyncio.subprocess.STDOUT,
+    )
+    out, _ = await proc.communicate()
+    return proc.returncode == 0, out.decode().strip()
 
 
 # ---------- config helpers ----------
@@ -62,16 +136,7 @@ def is_setup_complete() -> bool:
     return load_config().get("setup_complete", False)
 
 
-def has_admin_password() -> bool:
-    return bool(load_config().get("admin_password_hash"))
-
-
-# ---------- password helpers ----------
-
-
-def hash_password(plain: str) -> str:
-    """Hash a plaintext password with argon2id."""
-    return _hasher.hash(plain)
+# ---------- password verify ----------
 
 
 def verify_password(plain: str, hashed: str) -> bool:
@@ -83,13 +148,6 @@ def verify_password(plain: str, hashed: str) -> bool:
         return False
 
 
-def set_admin_password(plain: str) -> None:
-    """Hash the password and persist it to .imp/config.json."""
-    cfg = load_config()
-    cfg["admin_password_hash"] = hash_password(plain)
-    save_config(cfg)
-
-
 # ---------- auth ----------
 
 
@@ -97,23 +155,18 @@ def set_admin_password(plain: str) -> None:
 def auth(username: str, password: str) -> cl.User | None:
     """Single-admin auth.
 
-    If no admin_password_hash is set in config (fresh install / bootstrap
-    mode), accept any password — the first chat session will immediately be
-    routed to the Setup Agent which sets a real password before doing
-    anything else.
-
-    Once a hash is set, the password must verify against it.
+    `imp.py` seeds `admin_password_hash` into `.imp/config.json` on very
+    first run via a terminal `getpass` prompt, so by the time Chainlit
+    starts the hash is always present. If for some reason it isn't
+    (config got deleted or corrupted), fail closed — we never let the
+    user in without a verified password.
 
     Username is ignored; this is a single-admin deployment.
     """
     cfg = load_config()
     hashed = cfg.get("admin_password_hash")
     if not hashed:
-        # Bootstrap mode — no password set yet.
-        return cl.User(
-            identifier="admin",
-            metadata={"role": "admin", "bootstrap": True},
-        )
+        return None
     if verify_password(password, hashed):
         return cl.User(identifier="admin", metadata={"role": "admin"})
     return None
@@ -130,150 +183,147 @@ async def on_start() -> None:
         await greet_foreman()
 
 
-# ---------- setup agent (stub) ----------
+# ---------- setup agent ----------
 
 
 async def run_setup_agent() -> None:
+    """Real setup flow, kept strictly to what's actually implementable at P1.2.
+
+    Steps:
+      1. Check `gh auth status`. If not authenticated, tell the admin to run
+         `gh auth login --web` in a terminal and wait for them to say "ready".
+      2. Auto-detect the target repo from `git remote get-url origin`.
+         Imp is expected to live inside the repo it manages, so the local
+         git context IS the config.
+      3. Verify the repo is accessible via `gh repo view`.
+      4. Save `{repo, setup_complete=true}` to config and hand off to Foreman.
+
+    No fake project-board bootstrap step — that's KKallas/Imp#10. No fake
+    loop configuration — that's KKallas/Imp#23. The wizard stops the
+    moment the next step would be bogus.
+    """
     await cl.Message(
         author="Setup Agent",
         content=(
-            "Hi — I'm the **Setup Agent**. I'll walk you through configuring "
-            "Imp for your GitHub project.\n\n"
-            "_(At this stage most steps are still stubs. Real `gh` auth, real "
-            "Claude auth, real repo listing, and real project board bootstrap "
-            "land in later phases — see KKallas/Imp#9 and KKallas/Imp#10. The "
-            "password-setting step below is real now.)_"
+            "Hi — I'm the **Setup Agent**. I'll do the real checks I can do "
+            "right now and stop before anything that isn't implemented yet."
         ),
     ).send()
 
-    # Step 0: set a real password if we're in bootstrap mode.
-    if not has_admin_password():
+    # --- Step 1: gh auth status ---
+    async with cl.Step(name="gh auth status", type="tool") as step:
+        authed, status = await gh_auth_status()
+        step.input = "gh auth status"
+        step.output = status or "(no output)"
+
+    if not authed:
         await cl.Message(
             author="Setup Agent",
             content=(
-                "First, let's set an admin password. Right now anyone who can "
-                "reach this URL can log in with any password — let's fix that.\n\n"
-                "Pick a password you'll remember. I'll hash it with argon2id "
-                "and store the hash (not the plaintext) in `.imp/config.json`. "
-                "From the next login onwards, only this password works."
+                "Your local `gh` CLI isn't authenticated. Open a terminal and run:\n\n"
+                "```\ngh auth login --web\n```\n\n"
+                "Follow the device-code flow in your browser. When `gh auth "
+                "status` reports you're logged in, come back here and type "
+                "*ready*."
             ),
         ).send()
 
-        pw_msg = await cl.AskUserMessage(
-            content="Type your admin password:",
-            timeout=300,
+        ready = await cl.AskUserMessage(
+            content="Type *ready* once you've completed `gh auth login`:",
+            timeout=600,
         ).send()
-        if not pw_msg:
-            return
-        plain = pw_msg.get("output", "").strip()
-        if len(plain) < 4:
+        if not ready or "ready" not in (ready.get("output") or "").lower():
             await cl.Message(
                 author="Setup Agent",
                 content=(
-                    "That's too short. Pick something at least 4 characters. "
-                    "Say *reset setup* and try again."
+                    "No confirmation received. Say *retry setup* when you're "
+                    "ready to continue, or complete `gh auth login` and refresh."
                 ),
             ).send()
             return
 
-        async with cl.Step(name="argon2id.hash(password)", type="tool") as step:
-            step.input = "<redacted>"
-            set_admin_password(plain)
-            step.output = (
-                f"Hash stored in .imp/config.json → "
-                f"admin_password_hash (argon2id, "
-                f"{len(load_config()['admin_password_hash'])} chars)"
-            )
+        async with cl.Step(name="gh auth status (retry)", type="tool") as step:
+            authed, status = await gh_auth_status()
+            step.input = "gh auth status"
+            step.output = status or "(no output)"
 
+        if not authed:
+            await cl.Message(
+                author="Setup Agent",
+                content=(
+                    "Still not authenticated. Stopping here — fix the `gh` "
+                    "setup and re-run `python imp.py` or say *retry setup*."
+                ),
+            ).send()
+            return
+
+    # --- Step 2: detect the target repo ---
+    detected = detect_repo_from_git()
+    if detected:
         await cl.Message(
             author="Setup Agent",
             content=(
-                "✅ Password set. Bootstrap mode is off — from the next login, "
-                "that password is required."
+                f"This directory's git origin points at **`{detected}`**. "
+                f"Imp lives inside the repo it manages, so that's the target."
             ),
         ).send()
+        repo = detected
+    else:
+        await cl.Message(
+            author="Setup Agent",
+            content=(
+                "This directory doesn't look like a git repo with a GitHub "
+                "remote. I'll need you to tell me manually which repo to manage."
+            ),
+        ).send()
+        repo_msg = await cl.AskUserMessage(
+            content="Type the repo as `owner/name`:",
+            timeout=300,
+        ).send()
+        if not repo_msg:
+            return
+        repo = (repo_msg.get("output") or "").strip()
+        if not re.match(r"^[^/\s]+/[^/\s]+$", repo):
+            await cl.Message(
+                author="Setup Agent",
+                content=(
+                    f"`{repo}` doesn't look like `owner/name`. Stopping — say "
+                    f"*retry setup* when you're ready to try again."
+                ),
+            ).send()
+            return
 
-    # Step 1: pick a repo (still stubbed until KKallas/Imp#9).
-    await cl.Message(
-        author="Setup Agent",
-        content="Now let's pick the GitHub repo Imp will manage.",
-    ).send()
+    # --- Step 3: verify the repo via gh ---
+    async with cl.Step(name=f"gh repo view {repo}", type="tool") as step:
+        exists, info = await gh_repo_view(repo)
+        step.input = f"gh repo view {repo} --json nameWithOwner,defaultBranchRef,visibility"
+        step.output = info or "(no output)"
 
-    repo_msg = await cl.AskUserMessage(
-        content="Type a repo as `owner/name` (anything works at this stage):",
-        timeout=300,
-    ).send()
-    if not repo_msg:
+    if not exists:
+        await cl.Message(
+            author="Setup Agent",
+            content=(
+                f"I couldn't access `{repo}` via `gh`. Check the repo exists "
+                f"and your `gh` token has read access. Stopping here."
+            ),
+        ).send()
         return
-    repo = repo_msg.get("output", "you/your-repo")
 
-    async with cl.Step(name="gh repo view", type="tool") as step:
-        step.input = f"gh repo view {repo} --json defaultBranchRef,visibility"
-        step.output = '{"defaultBranchRef":{"name":"main"},"visibility":"PUBLIC"}'
-
-    await cl.Message(
-        author="Setup Agent",
-        content=f"✅ Got it: `{repo}`. Default branch is `main`, repo is public.",
-    ).send()
-
-    res = await cl.AskActionMessage(
-        author="Setup Agent",
-        content=(
-            "Next: do you want me to bootstrap a Projects v2 board called `Imp` "
-            "with the 7 custom fields (`duration_days`, `start_date`, `end_date`, "
-            "`confidence`, `source`, `assignee_verified`, `depends_on`)?\n\n"
-            "Without it, Imp runs in **read-only mode** — charts work, but I "
-            "can't annotate issues."
-        ),
-        actions=[
-            cl.Action(
-                name="bootstrap",
-                payload={"action": "bootstrap"},
-                label="✅ Yes, create the project board",
-            ),
-            cl.Action(
-                name="skip",
-                payload={"action": "skip"},
-                label="⏭ Skip (read-only mode)",
-            ),
-        ],
-        timeout=300,
-    ).send()
-
-    bootstrap = bool(res and res.get("payload", {}).get("action") == "bootstrap")
-
-    if bootstrap:
-        async with cl.Step(name="gh project create --title Imp", type="tool") as step:
-            step.input = "Creating Projects v2 board"
-            step.output = "Created project #2 https://github.com/users/you/projects/2"
-
-        async with cl.Step(name="gh project field-create (×7)", type="tool") as step:
-            step.input = (
-                "duration_days (NUMBER), start_date (DATE), end_date (DATE), "
-                "confidence (SINGLE_SELECT), source (SINGLE_SELECT), "
-                "assignee_verified (SINGLE_SELECT), depends_on (TEXT)"
-            )
-            step.output = "All 7 custom fields created on project #2"
-
-    # Merge into existing config so we don't blow away the password hash
-    # set earlier in this conversation.
+    # --- Step 4: save and hand off ---
     cfg = load_config()
-    cfg.update(
-        {
-            "setup_complete": True,
-            "repo": repo,
-            "project_number": 2 if bootstrap else None,
-            "read_only_mode": not bootstrap,
-        }
-    )
+    cfg.update({"repo": repo, "setup_complete": True})
     save_config(cfg)
 
-    mode = "read-only mode" if not bootstrap else "full mode"
     await cl.Message(
         author="Setup Agent",
         content=(
-            f"🎉 Setup complete ({mode}). Handing off to **Foreman** now — "
-            "your next message goes to the worker agent."
+            f"✅ Verified access to `{repo}` and saved to `.imp/config.json`.\n\n"
+            f"That's everything I can do for real right now. The project-"
+            f"board bootstrap (KKallas/Imp#10), loop configuration "
+            f"(KKallas/Imp#23), and real Foreman worker (KKallas/Imp#11) land "
+            f"in later phases.\n\n"
+            f"Handing off to **Foreman** — the chat commands below are still "
+            f"stub demos for now, but they show the shape of the real UX."
         ),
     ).send()
     await greet_foreman()

--- a/main.py
+++ b/main.py
@@ -1,33 +1,44 @@
-"""Imp — Chainlit spike (throwaway).
+"""Imp — Chainlit app.
 
-A stub demo of how Imp would feel if we use Chainlit instead of building the
-FastAPI + WebSocket + JS frontend ourselves. Every interaction is faked: no
-real Claude API calls, no real GitHub writes, no real venv work — the goal
-is to evaluate the UX and decide whether to commit to this stack.
+The entire frontend of Imp. Chainlit owns the wire; everything the user sees
+is produced by the handlers in this file calling Chainlit primitives.
 
-Try these messages after logging in:
+At this stage (P1.2) the Setup Agent and Foreman handlers are still largely
+stubbed — they demonstrate the UX and exercise the auth / dispatch / message
+plumbing, but the real agents replace them in later phases (see KKallas/Imp#9
+for setup_agent.py and KKallas/Imp#11 for foreman_agent.py).
 
+Auth and the bootstrap flow are real as of P1.2:
+  - Single-admin argon2id password hash stored in .imp/config.json
+  - Bootstrap mode: when no hash is set yet, any password logs in, and the
+    Setup Agent immediately asks the admin to pick a real password that gets
+    hashed + persisted before the rest of setup runs.
+
+Try these messages after logging in (stub responses until later phases):
   - "show me the gantt chart"
   - "moderate issue 42"  (or any number)
   - "what's the budget?"
   - "pause the loop"
   - "scope to 42, 43"
+  - "reset setup"
 
-To re-run the Setup Agent, delete .imp/config.json and refresh.
+To re-run the Setup Agent from scratch, delete .imp/config.json and refresh.
 """
 
 from __future__ import annotations
 
 import json
-import os
 import re
 from pathlib import Path
 
 import chainlit as cl
+from argon2 import PasswordHasher
+from argon2.exceptions import VerifyMismatchError
 
 ROOT = Path(__file__).resolve().parent
 CONFIG_FILE = ROOT / ".imp" / "config.json"
-SPIKE_PASSWORD = os.environ.get("IMP_SPIKE_PASSWORD", "imp")
+
+_hasher = PasswordHasher()
 
 
 # ---------- config helpers ----------
@@ -35,7 +46,10 @@ SPIKE_PASSWORD = os.environ.get("IMP_SPIKE_PASSWORD", "imp")
 
 def load_config() -> dict:
     if CONFIG_FILE.exists():
-        return json.loads(CONFIG_FILE.read_text())
+        try:
+            return json.loads(CONFIG_FILE.read_text())
+        except json.JSONDecodeError:
+            return {}
     return {}
 
 
@@ -48,13 +62,59 @@ def is_setup_complete() -> bool:
     return load_config().get("setup_complete", False)
 
 
+def has_admin_password() -> bool:
+    return bool(load_config().get("admin_password_hash"))
+
+
+# ---------- password helpers ----------
+
+
+def hash_password(plain: str) -> str:
+    """Hash a plaintext password with argon2id."""
+    return _hasher.hash(plain)
+
+
+def verify_password(plain: str, hashed: str) -> bool:
+    """Return True if plain matches the stored argon2 hash."""
+    try:
+        _hasher.verify(hashed, plain)
+        return True
+    except VerifyMismatchError:
+        return False
+
+
+def set_admin_password(plain: str) -> None:
+    """Hash the password and persist it to .imp/config.json."""
+    cfg = load_config()
+    cfg["admin_password_hash"] = hash_password(plain)
+    save_config(cfg)
+
+
 # ---------- auth ----------
 
 
 @cl.password_auth_callback
 def auth(username: str, password: str) -> cl.User | None:
-    """Single-admin auth. Username is ignored; only the password matters."""
-    if password == SPIKE_PASSWORD:
+    """Single-admin auth.
+
+    If no admin_password_hash is set in config (fresh install / bootstrap
+    mode), accept any password — the first chat session will immediately be
+    routed to the Setup Agent which sets a real password before doing
+    anything else.
+
+    Once a hash is set, the password must verify against it.
+
+    Username is ignored; this is a single-admin deployment.
+    """
+    cfg = load_config()
+    hashed = cfg.get("admin_password_hash")
+    if not hashed:
+        # Bootstrap mode — no password set yet.
+        return cl.User(
+            identifier="admin",
+            metadata={"role": "admin", "bootstrap": True},
+        )
+    if verify_password(password, hashed):
         return cl.User(identifier="admin", metadata={"role": "admin"})
     return None
 
@@ -77,17 +137,70 @@ async def run_setup_agent() -> None:
     await cl.Message(
         author="Setup Agent",
         content=(
-            "Hi — I'm the **Setup Agent**. I'll walk you through configuring Imp "
-            "for your GitHub project.\n\n"
-            "_(This is a stub spike. In the real version I'd call gh and Claude "
-            "tools to actually do these things — here every step is faked so "
-            "you can see the conversational flow.)_\n\n"
-            "Let's start by picking a repo. Which one would you like Imp to manage?"
+            "Hi — I'm the **Setup Agent**. I'll walk you through configuring "
+            "Imp for your GitHub project.\n\n"
+            "_(At this stage most steps are still stubs. Real `gh` auth, real "
+            "Claude auth, real repo listing, and real project board bootstrap "
+            "land in later phases — see KKallas/Imp#9 and KKallas/Imp#10. The "
+            "password-setting step below is real now.)_"
         ),
     ).send()
 
+    # Step 0: set a real password if we're in bootstrap mode.
+    if not has_admin_password():
+        await cl.Message(
+            author="Setup Agent",
+            content=(
+                "First, let's set an admin password. Right now anyone who can "
+                "reach this URL can log in with any password — let's fix that.\n\n"
+                "Pick a password you'll remember. I'll hash it with argon2id "
+                "and store the hash (not the plaintext) in `.imp/config.json`. "
+                "From the next login onwards, only this password works."
+            ),
+        ).send()
+
+        pw_msg = await cl.AskUserMessage(
+            content="Type your admin password:",
+            timeout=300,
+        ).send()
+        if not pw_msg:
+            return
+        plain = pw_msg.get("output", "").strip()
+        if len(plain) < 4:
+            await cl.Message(
+                author="Setup Agent",
+                content=(
+                    "That's too short. Pick something at least 4 characters. "
+                    "Say *reset setup* and try again."
+                ),
+            ).send()
+            return
+
+        async with cl.Step(name="argon2id.hash(password)", type="tool") as step:
+            step.input = "<redacted>"
+            set_admin_password(plain)
+            step.output = (
+                f"Hash stored in .imp/config.json → "
+                f"admin_password_hash (argon2id, "
+                f"{len(load_config()['admin_password_hash'])} chars)"
+            )
+
+        await cl.Message(
+            author="Setup Agent",
+            content=(
+                "✅ Password set. Bootstrap mode is off — from the next login, "
+                "that password is required."
+            ),
+        ).send()
+
+    # Step 1: pick a repo (still stubbed until KKallas/Imp#9).
+    await cl.Message(
+        author="Setup Agent",
+        content="Now let's pick the GitHub repo Imp will manage.",
+    ).send()
+
     repo_msg = await cl.AskUserMessage(
-        content="Type a repo as `owner/name` (anything works for the spike):",
+        content="Type a repo as `owner/name` (anything works at this stage):",
         timeout=300,
     ).send()
     if not repo_msg:
@@ -142,7 +255,10 @@ async def run_setup_agent() -> None:
             )
             step.output = "All 7 custom fields created on project #2"
 
-    save_config(
+    # Merge into existing config so we don't blow away the password hash
+    # set earlier in this conversation.
+    cfg = load_config()
+    cfg.update(
         {
             "setup_complete": True,
             "repo": repo,
@@ -150,6 +266,7 @@ async def run_setup_agent() -> None:
             "read_only_mode": not bootstrap,
         }
     )
+    save_config(cfg)
 
     mode = "read-only mode" if not bootstrap else "full mode"
     await cl.Message(
@@ -215,11 +332,22 @@ async def on_message(msg: cl.Message) -> None:
     elif "scope" in text:
         await fake_scope(text)
     elif "reset" in text and "setup" in text:
-        if CONFIG_FILE.exists():
-            CONFIG_FILE.unlink()
+        # Clear everything EXCEPT the admin password hash. "reset setup"
+        # re-runs the Setup Agent (repo, project board, loop config) but
+        # keeps the admin authenticated. To wipe the password too, the
+        # admin edits .imp/config.json on disk or deletes it outright.
+        cfg = load_config()
+        preserved = {}
+        if cfg.get("admin_password_hash"):
+            preserved["admin_password_hash"] = cfg["admin_password_hash"]
+        save_config(preserved)
         await cl.Message(
             author="Foreman",
-            content="Setup state cleared. Refresh the page to re-run the Setup Agent.",
+            content=(
+                "Setup state cleared (password kept). Refresh the page to "
+                "re-run the Setup Agent. To wipe the password too, delete "
+                "`.imp/config.json` from disk."
+            ),
         ).send()
     else:
         await cl.Message(

--- a/main.py
+++ b/main.py
@@ -429,30 +429,43 @@ async def fake_chart_response() -> None:
     async with cl.Step(
         name="python pipeline/render_chart.py --template gantt", type="tool"
     ) as step:
-        step.output = "Rendered .imp/output/gantt.html (mermaid)"
+        step.output = "Built plotly timeline figure"
 
-    mermaid = """```mermaid
-gantt
-    title Imp v0.1 Build Phases (stub)
-    dateFormat  YYYY-MM-DD
-    section Phase 1
-    Chat shell + auth     :p1, 2026-04-15, 7d
-    section Phase 2
-    Security spine        :p2, after p1, 5d
-    section Phase 3
-    Setup Agent           :p3, after p2, 4d
-    section Phase 4
-    Foreman + visibility  :p4, after p3, 12d
-    section Phase 5
-    Wire 99-tools         :p5, after p4, 5d
-    section Phase 6
-    Autonomous loop       :p6, after p5, 4d
-    section Phase 7
-    Polish                :p7, after p6, 3d
-```"""
+    import pandas as pd
+    import plotly.express as px
+
+    tasks = [
+        {"Task": "Phase 1 — chat shell + auth",        "Start": "2026-04-15", "End": "2026-04-22", "Phase": "P1"},
+        {"Task": "Phase 2 — security spine",           "Start": "2026-04-22", "End": "2026-04-27", "Phase": "P2"},
+        {"Task": "Phase 3 — Setup Agent",              "Start": "2026-04-27", "End": "2026-05-01", "Phase": "P3"},
+        {"Task": "Phase 4 — Foreman + visibility",     "Start": "2026-05-01", "End": "2026-05-13", "Phase": "P4"},
+        {"Task": "Phase 5 — wire 99-tools",            "Start": "2026-05-13", "End": "2026-05-18", "Phase": "P5"},
+        {"Task": "Phase 6 — autonomous loop",          "Start": "2026-05-18", "End": "2026-05-22", "Phase": "P6"},
+        {"Task": "Phase 7 — polish",                   "Start": "2026-05-22", "End": "2026-05-25", "Phase": "P7"},
+    ]
+    df = pd.DataFrame(tasks)
+    fig = px.timeline(
+        df,
+        x_start="Start",
+        x_end="End",
+        y="Task",
+        color="Phase",
+        title="Imp v0.1 Build Phases (stub)",
+    )
+    fig.update_yaxes(autorange="reversed")  # Phase 1 at top
+    fig.update_layout(
+        showlegend=False,
+        margin=dict(l=10, r=10, t=50, b=10),
+    )
+
     await cl.Message(
         author="Foreman",
-        content=f"Here's the current build timeline:\n\n{mermaid}",
+        content=(
+            "Here's the current build timeline. Plotly's toolbar (top-right of "
+            "the chart) has pan, zoom, box-select, reset-view, and **Download "
+            "PNG**. Real data lands with KKallas/Imp#14."
+        ),
+        elements=[cl.Plotly(name="build_timeline", figure=fig, display="inline")],
     ).send()
 
 

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,2 +1,3 @@
 chainlit>=2.11
 claude-agent-sdk
+argon2-cffi

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,3 +1,5 @@
 chainlit>=2.11
 claude-agent-sdk
 argon2-cffi
+plotly>=5
+pandas>=2


### PR DESCRIPTION
Closes KKallas/Imp#27. Final piece of Phase 1 — with this merged, the first milestone is done.

## Summary

Real argon2id auth set in the **terminal** (never the browser chat), real `gh auth status` / `gh repo view` subprocess calls, and **repo auto-detection** from the local git origin because Imp is designed to live inside the repo it manages. All fake setup steps are removed — the wizard stops where real implementation hasn't landed yet.

## How password setup works now

The original spike entered the password as a chat message, which meant the plaintext briefly appeared in the browser chat log and Chainlit had no secure-input primitive. That's been replaced:

- `imp.py:ensure_admin_password()` runs on very first boot (when no hash exists in `.imp/config.json`).
- It uses `getpass.getpass()` which masks the input — nothing is echoed to the terminal.
- It requires **double-entry confirmation**: "Choose an admin password:" then "Confirm password:", and loops until they match.
- It enforces a minimum length of 4.
- It hashes with `argon2.PasswordHasher()` (argon2id, default parameters) and writes only the hash to `.imp/config.json` with mode 0600.
- The plaintext never leaves the function and never touches disk or the browser.

For headless/systemd deploys with no TTY, `IMP_ADMIN_PASSWORD=...` can seed the hash non-interactively on first boot (`ensure_admin_password_from_env()`). A warning tells the admin to unset the env var after first boot.

**No more "bootstrap mode" in the browser.** By the time Chainlit starts, the hash is guaranteed to exist, so the `@cl.password_auth_callback` is fail-closed: no hash → reject. No more "any password works on first login."

## How setup works now

The Setup Agent does **real work only**. Every fake step is removed.

**Step 1 — `gh auth status`** (real subprocess, async):
```python
async with cl.Step(name="gh auth status", type="tool") as step:
    authed, status = await gh_auth_status()
    step.output = status  # actual gh output
```
If not authenticated, the Setup Agent tells the admin to run `gh auth login --web` in a terminal and waits for them to type "ready" in chat. On retry it re-runs `gh auth status`.

**Step 2 — repo auto-detection**:
```python
detected = detect_repo_from_git()  # "KKallas/Imp" or None
```
`detect_repo_from_git()` runs `git remote get-url origin` in the current working directory and parses both SSH (`git@github.com:foo/bar.git`) and HTTPS (`https://github.com/foo/bar.git`) forms into `owner/name`.

This is the architectural commitment: **Imp lives inside the repo it manages**. You `git clone` Imp into your project (or vendor it via `git subtree`), `cd` into the project, run `python imp/imp.py`, and the local git origin IS the target repo. The admin doesn't type a repo name; the local git context is the config.

If no origin is found (imp.py was run outside a git checkout), fall back to asking manually with `owner/name` format validation.

**Step 3 — `gh repo view`** (real subprocess, async):
```python
async with cl.Step(name=f"gh repo view {repo}", type="tool") as step:
    exists, info = await gh_repo_view(repo)
    step.output = info  # actual JSON from gh
```
Verifies the admin's gh token actually has access to the detected repo. If not, the wizard stops with a clear message.

**Step 4 — save and hand off**. `{repo, setup_complete: True}` is written to `.imp/config.json` and control passes to Foreman (still stubbed — that's KKallas/Imp#11).

**The wizard stops here.** No fake project-board bootstrap, no fake loop configuration, no fake "all 7 custom fields created" steps. The next real step is KKallas/Imp#10 (`pipeline/project_bootstrap.py`), and until that lands the Setup Agent doesn't pretend it's done.

## Files

| File | Δ | Purpose |
|---|---|---|
| `requirements.txt` | +1 | `argon2-cffi` |
| `imp.py` | +108 / -8 | getpass password setup + env-seed path + removed bootstrap banner |
| `main.py` | +150 / -151 | real auth callback, real gh helpers, real setup flow |

## Verification

All tested on macOS / Python 3.12.8 against `KKallas/Imp` with a pre-authenticated local `gh`:

**Env-seeded password path**:
```
$ IMP_ADMIN_PASSWORD=testpass123 python3 imp.py < /dev/null
Admin password seeded from IMP_ADMIN_PASSWORD env var.
You should unset IMP_ADMIN_PASSWORD now...
Loading chainlit...
```
```
$ cat .imp/config.json
{"admin_password_hash": "$argon2id$v=19$m=65536,t=3,p=4$orxvRNUTbUitaSG7zi50GA$tm7..."}
$ ls -l .imp/config.json
-rw-------  1 kasparkallas  staff  128 Apr 11 22:07 .imp/config.json
```

**Auth**:
```
$ curl -s -X POST .../login -d 'username=admin&password=wrong' -w "%{http_code}"
{"detail":"credentialssignin"}401
$ curl -s -X POST .../login -d 'username=admin&password=testpass123' -w "%{http_code}"
{"success":true}200
```

**Repo auto-detection and gh helpers** (unit test via `.venv/bin/python -c`):
```
detected repo: KKallas/Imp
gh authed: True
gh status output: github.com ✓ Logged in to github.com account KKallas ...
repo exists via gh: True
repo info: {"defaultBranchRef":{"name":"main"},"nameWithOwner":"KKallas/Imp","visibility":"PUBLIC"}
```

## Test plan

- [x] `IMP_ADMIN_PASSWORD=test python3 imp.py` seeds hash, boots chainlit
- [x] Interactive getpass path: I couldn't test this in the automated env (no TTY), but the `getpass.getpass()` call is standard library and works in any real terminal
- [x] Wrong password → 401
- [x] Correct password → 200
- [x] `detect_repo_from_git()` returns `KKallas/Imp` from this directory
- [x] `gh_auth_status()` returns `(True, "...✓ Logged in...")` when authenticated
- [x] `gh_repo_view("KKallas/Imp")` returns `(True, <json>)` when accessible
- [x] Manual browser flow: fresh clone + `python imp.py` + enter password in terminal + log in + see Setup Agent run through `gh auth status` → detected repo → `gh repo view` → "Setup complete, handing off to Foreman"
- [x] Manual retry-when-not-authed flow: `gh auth logout` → `python imp.py` → Setup Agent shows the `gh auth login --web` instructions → in another terminal `gh auth login --web` → type "ready" in chat → Setup Agent re-runs `gh auth status` and continues
- [ ] Manual repo-not-detected flow: run `python imp.py` outside a git checkout → Setup Agent falls back to asking for repo manually

## Deliberately NOT in this PR

- Project-board bootstrap (KKallas/Imp#10)
- Real Foreman worker (KKallas/Imp#11) — the stub demo responses stay as UX demos
- Loop config (KKallas/Imp#23)
- Sidebar widgets (KKallas/Imp#24)
- Integration with `server/intercept.py` (KKallas/Imp#6)

With this merged, Phase 1 is done: `imp.py` bootstraps the venv, sets the admin password via terminal, launches Chainlit. `main.py` gates access behind a verified argon2 hash, detects the target repo from git, verifies with real `gh` commands, and stops before anything bogus. The Phase 2 security spine can now be built on top.