### PR TITLE
[P2.6] server/intercept.py — action interception + runtime control spine

### DIFF
--- a/main.py
+++ b/main.py
@@ -486,9 +486,10 @@ async def run_demo_command(user_content: str) -> None:
             step=step,
         )
 
-    # Collapsed-by-default step with the full verdict table. The step name
-    # is a one-liner summary; click the name to expand and see the full
-    # table, classification, guard reason, etc.
+    # Collapsed-by-default step with just the verdict table. No elements
+    # attached — we use a separate action button below the step so the
+    # user can explicitly open the log sidebar, instead of Chainlit
+    # auto-pushing side elements on step completion.
     summary = (
         f"intercept.py result · {action.action_id} · "
         f"{action.verdict} · rc={rc}"
@@ -506,26 +507,34 @@ async def run_demo_command(user_content: str) -> None:
             f"| classified_as | `{action.classified_as}` |\n"
             f"| verdict | `{action.verdict}` |\n"
             f"| verdict_reason | {action.verdict_reason or '—'} |\n"
-            f"| return code | `{rc}` |\n"
-            f"| log file | `.imp/output/{action.action_id}.log` |"
+            f"| return code | `{rc}` |"
         )
 
-    # Always-visible clickable link to the log file, opens on the side.
-    # cl.File with mime=text/plain + language=plaintext tells Chainlit's
-    # side viewer to render as monospace plain text.
+    # Below the step: a small message with an action button (opens the
+    # log sidebar on click — closing and re-clicking works because the
+    # callback explicitly calls ElementSidebar.set_elements every time)
+    # plus an inline download chip. Sidebar stays closed until the user
+    # explicitly clicks the "Open log" button.
     log_path = intercept.OUTPUT_DIR / f"{action.action_id}.log"
     if log_path.exists():
         await cl.Message(
             author="Foreman",
-            content=f"📄 Log file:",
+            content=f"📄 `{action.action_id}.log`:",
+            actions=[
+                cl.Action(
+                    name="open_log_sidebar",
+                    payload={"action_id": action.action_id},
+                    label="📂 Open log",
+                    tooltip="View the log contents in the side panel",
+                ),
+            ],
             elements=[
                 cl.File(
                     name=f"{action.action_id}.log",
                     path=str(log_path),
-                    display="side",
+                    display="inline",
                     mime="text/plain",
-                    language="plaintext",
-                )
+                ),
             ],
         ).send()
 
@@ -536,10 +545,9 @@ async def _view_log_by_id(action_id: str) -> None:
     Shared by the `log <id>` chat command and the `view_log` action
     callback. Accepts either `act_xxxxxxxx` or bare `xxxxxxxx`.
 
-    The log is attached as a `cl.File(display="side")` so clicking the
-    chip opens the file on the side in Chainlit's native file viewer.
-    `mime="text/plain"` + `language="plaintext"` tells the viewer to
-    render as monospace plaintext.
+    Posts a message with two elements: a `cl.Text(display="side")`
+    that shows the contents when clicked, and a `cl.File(display="inline")`
+    as a download chip.
     """
     from server import intercept
 
@@ -556,18 +564,31 @@ async def _view_log_by_id(action_id: str) -> None:
         ).send()
         return
 
+    try:
+        content = log_path.read_text()
+    except OSError as e:
+        await cl.Message(
+            author="Foreman",
+            content=f"Couldn't read `{log_path}`: {e}",
+        ).send()
+        return
+
     size = log_path.stat().st_size
     await cl.Message(
         author="Foreman",
-        content=f"📄 `{action_id}.log` ({size} bytes) — click to view on the side:",
+        content=f"Log `{action_id}.log` ({size} bytes):",
         elements=[
+            cl.Text(
+                name=f"{action_id}.log",
+                content=content or "(empty)",
+                display="side",
+            ),
             cl.File(
                 name=f"{action_id}.log",
                 path=str(log_path),
-                display="side",
+                display="inline",
                 mime="text/plain",
-                language="plaintext",
-            )
+            ),
         ],
     ).send()
 
@@ -579,6 +600,44 @@ async def on_view_log_action(action: cl.Action) -> None:
     if not action_id:
         return
     await _view_log_by_id(action_id)
+
+
+@cl.action_callback("open_log_sidebar")
+async def on_open_log_sidebar(action: cl.Action) -> None:
+    """Open the side panel with the log contents.
+
+    Explicitly calls cl.ElementSidebar.set_elements every time — so if
+    the user closes the panel and clicks the button again, a fresh
+    sidebar opens with the same content. This is the only reliable way
+    I've found to get a "reopen the log" button in Chainlit 2.11.
+
+    Payload: {"action_id": "act_xxxxxxxx"}
+    """
+    from server import intercept
+
+    action_id = (action.payload or {}).get("action_id")
+    if not action_id:
+        return
+    log_path = intercept.OUTPUT_DIR / f"{action_id}.log"
+    if not log_path.exists():
+        return
+    try:
+        content = log_path.read_text()
+    except OSError:
+        return
+    try:
+        await cl.ElementSidebar.set_title(f"{action_id}.log")
+    except Exception:
+        pass
+    await cl.ElementSidebar.set_elements(
+        [
+            cl.Text(
+                name=f"{action_id}.log",
+                content=content or "(empty)",
+                display="side",
+            ),
+        ]
+    )
 
 
 async def show_log_command(user_content: str) -> None:

--- a/main.py
+++ b/main.py
@@ -486,22 +486,20 @@ async def run_demo_command(user_content: str) -> None:
             step=step,
         )
 
-    # Attach the log file contents as an inline element so each run gets
-    # its own self-contained view. display="side" causes Chainlit to
-    # append to an already-open side panel when a new run's element is
-    # created while the panel is visible — inline avoids that entirely.
+    # Attach the log as a cl.File so it shows up as a small clickable chip
+    # in the verdict message. Click to download or preview — no content is
+    # shown by default, nothing gets appended to shared panels, and every
+    # run is isolated.
     log_path = intercept.OUTPUT_DIR / f"{action.action_id}.log"
     elements = []
     if log_path.exists():
-        try:
-            log_content = log_path.read_text()
-        except OSError as e:
-            log_content = f"(failed to read log file: {e})"
         elements.append(
-            cl.Text(
+            cl.File(
                 name=f"{action.action_id}.log",
-                content=log_content or "(empty)",
+                path=str(log_path),
                 display="inline",
+                mime="text/plain",
+                size="small",
             )
         )
 
@@ -515,14 +513,11 @@ async def run_demo_command(user_content: str) -> None:
             f"| classified_as | `{action.classified_as}` |\n"
             f"| verdict | `{action.verdict}` |\n"
             f"| verdict_reason | {action.verdict_reason} |\n"
-            f"| return code | `{rc}` |\n"
-            f"| log file | `.imp/output/{action.action_id}.log` |\n\n"
-            f"The captured log is inline below. You can also view it any time "
-            f"with `log {action.action_id}` in chat.\n\n"
-            f"This was a real subprocess, streamed live into the step above "
-            f"via `server/intercept.py:execute_command`. The stub guard "
-            f"auto-approved (see `_stub_guard`, replaced by the real Guard "
-            f"Agent in KKallas/Imp#7)."
+            f"| return code | `{rc}` |\n\n"
+            f"Click the `{action.action_id}.log` chip below to open the log "
+            f"file, or type `log {action.action_id}` in chat to view it "
+            f"inline. The command is also streamed live into the step above "
+            f"via `server/intercept.py:execute_command`."
         ),
         elements=elements,
     ).send()

--- a/main.py
+++ b/main.py
@@ -360,6 +360,14 @@ async def on_message(msg: cl.Message) -> None:
 
     text = msg.content.lower().strip()
 
+    # Demo hook for P2.6: `run: <cmd>` runs the command through the real
+    # server/intercept.py pipeline. See tests/test_intercept.py for the
+    # underlying contract. This is how you'd exercise the interception
+    # spine end-to-end before the real Foreman worker lands (KKallas/Imp#11).
+    if msg.content.lower().startswith("run:") or msg.content.lower().startswith("run "):
+        await run_demo_command(msg.content)
+        return
+
     if any(k in text for k in ("gantt", "chart", "timeline")):
         await fake_chart_response()
     elif any(k in text for k in ("moderate", "solve", "fix")):
@@ -409,9 +417,80 @@ async def on_message(msg: cl.Message) -> None:
                 "- *budget*\n"
                 "- *pause* / *resume*\n"
                 "- *scope to 42, 43*\n"
-                "- *reset setup* (re-runs the Setup Agent on next refresh)"
+                "- *reset setup* (re-runs the Setup Agent on next refresh)\n"
+                "- *run: echo hello* (exercises server/intercept.py "
+                "end-to-end, real pipeline)"
             ),
         ).send()
+
+
+# ---------- real intercept demo (P2.6) ----------
+
+
+async def run_demo_command(user_content: str) -> None:
+    """Run `run: <cmd>` or `run <cmd>` through server/intercept.py.
+
+    This is the P2.6 demo: the interception pipeline is real — the
+    subprocess is spawned for real, stdout/stderr stream live into the
+    `cl.Step`, and the final verdict / budget update is applied. The
+    stub guard in `intercept._stub_guard` auto-approves every write,
+    so you can safely test the full flow without real GitHub writes by
+    sticking to safe read-only commands like `echo`, `date`, `ls`, `sleep`.
+    """
+    import shlex
+
+    from server import intercept
+
+    # Strip the "run:" or "run " prefix, preserving the rest verbatim
+    stripped = user_content.strip()
+    if stripped.lower().startswith("run:"):
+        cmd_str = stripped[4:].strip()
+    else:
+        cmd_str = stripped[4:].strip()
+    if not cmd_str:
+        await cl.Message(
+            author="Foreman",
+            content="Usage: `run: <command>` — e.g. `run: echo hello` or `run: date`.",
+        ).send()
+        return
+
+    try:
+        argv = shlex.split(cmd_str)
+    except ValueError as e:
+        await cl.Message(
+            author="Foreman",
+            content=f"Couldn't parse the command (`{e}`). Try again with simpler quoting.",
+        ).send()
+        return
+
+    async with cl.Step(name=f"intercept: {' '.join(argv)}", type="tool") as step:
+        step.input = cmd_str
+        rc, output, action = await intercept.execute_command(
+            argv,
+            user_intent=user_content,
+            rationale="Admin demo of server/intercept.py via chat",
+            kind="demo",
+            step=step,
+        )
+
+    await cl.Message(
+        author="Foreman",
+        content=(
+            f"**intercept.py result**\n\n"
+            f"| Field | Value |\n"
+            f"|---|---|\n"
+            f"| action_id | `{action.action_id}` |\n"
+            f"| classified_as | `{action.classified_as}` |\n"
+            f"| verdict | `{action.verdict}` |\n"
+            f"| verdict_reason | {action.verdict_reason} |\n"
+            f"| return code | `{rc}` |\n"
+            f"| log file | `.imp/output/{action.action_id}.log` |\n\n"
+            f"This was a real subprocess, streamed live into the step above "
+            f"via `server/intercept.py:execute_command`. The stub guard "
+            f"auto-approved (see `_stub_guard`, replaced by the real Guard "
+            f"Agent in KKallas/Imp#7)."
+        ),
+    ).send()
 
 
 # ---------- stub responses ----------

--- a/main.py
+++ b/main.py
@@ -486,8 +486,10 @@ async def run_demo_command(user_content: str) -> None:
             step=step,
         )
 
-    # Attach the log file contents as a side-panel element so the admin
-    # can view them after the live cl.Step is collapsed or scrolled past.
+    # Attach the log file contents as an inline element so each run gets
+    # its own self-contained view. display="side" causes Chainlit to
+    # append to an already-open side panel when a new run's element is
+    # created while the panel is visible — inline avoids that entirely.
     log_path = intercept.OUTPUT_DIR / f"{action.action_id}.log"
     elements = []
     if log_path.exists():
@@ -499,7 +501,7 @@ async def run_demo_command(user_content: str) -> None:
             cl.Text(
                 name=f"{action.action_id}.log",
                 content=log_content or "(empty)",
-                display="side",
+                display="inline",
             )
         )
 
@@ -515,9 +517,8 @@ async def run_demo_command(user_content: str) -> None:
             f"| verdict_reason | {action.verdict_reason} |\n"
             f"| return code | `{rc}` |\n"
             f"| log file | `.imp/output/{action.action_id}.log` |\n\n"
-            f"Click the **{action.action_id}.log** chip below to open the log "
-            f"in a side panel. You can also view it any time with `log "
-            f"{action.action_id}` in chat.\n\n"
+            f"The captured log is inline below. You can also view it any time "
+            f"with `log {action.action_id}` in chat.\n\n"
             f"This was a real subprocess, streamed live into the step above "
             f"via `server/intercept.py:execute_command`. The stub guard "
             f"auto-approved (see `_stub_guard`, replaced by the real Guard "

--- a/main.py
+++ b/main.py
@@ -486,48 +486,60 @@ async def run_demo_command(user_content: str) -> None:
             step=step,
         )
 
-    # Attach the log as a cl.File so it shows up as a small clickable chip
-    # in the verdict message. Click to download or preview — no content is
-    # shown by default, nothing gets appended to shared panels, and every
-    # run is isolated.
-    log_path = intercept.OUTPUT_DIR / f"{action.action_id}.log"
-    elements = []
-    if log_path.exists():
-        elements.append(
-            cl.File(
-                name=f"{action.action_id}.log",
-                path=str(log_path),
-                display="inline",
-                mime="text/plain",
-                size="small",
-            )
-        )
-
-    await cl.Message(
-        author="Foreman",
-        content=(
-            f"**intercept.py result**\n\n"
+    # Collapsed-by-default step with the full verdict table. The step name
+    # is a one-liner summary; click the name to expand and see the full
+    # table, classification, guard reason, etc.
+    summary = (
+        f"intercept.py result · {action.action_id} · "
+        f"{action.verdict} · rc={rc}"
+    )
+    async with cl.Step(
+        name=summary,
+        type="tool",
+        default_open=False,
+    ) as verdict_step:
+        verdict_step.input = cmd_str
+        verdict_step.output = (
             f"| Field | Value |\n"
             f"|---|---|\n"
             f"| action_id | `{action.action_id}` |\n"
             f"| classified_as | `{action.classified_as}` |\n"
             f"| verdict | `{action.verdict}` |\n"
-            f"| verdict_reason | {action.verdict_reason} |\n"
-            f"| return code | `{rc}` |\n\n"
-            f"Click the `{action.action_id}.log` chip below to open the log "
-            f"file, or type `log {action.action_id}` in chat to view it "
-            f"inline. The command is also streamed live into the step above "
-            f"via `server/intercept.py:execute_command`."
-        ),
-        elements=elements,
-    ).send()
+            f"| verdict_reason | {action.verdict_reason or '—'} |\n"
+            f"| return code | `{rc}` |\n"
+            f"| log file | `.imp/output/{action.action_id}.log` |"
+        )
+
+    # Always-visible clickable link to the log file, opens on the side.
+    # cl.File with mime=text/plain + language=plaintext tells Chainlit's
+    # side viewer to render as monospace plain text.
+    log_path = intercept.OUTPUT_DIR / f"{action.action_id}.log"
+    if log_path.exists():
+        await cl.Message(
+            author="Foreman",
+            content=f"📄 Log file:",
+            elements=[
+                cl.File(
+                    name=f"{action.action_id}.log",
+                    path=str(log_path),
+                    display="side",
+                    mime="text/plain",
+                    language="plaintext",
+                )
+            ],
+        ).send()
 
 
 async def _view_log_by_id(action_id: str) -> None:
-    """Post the contents of `.imp/output/<action_id>.log` as inline text.
+    """Post a clickable link to `.imp/output/<action_id>.log`.
 
     Shared by the `log <id>` chat command and the `view_log` action
     callback. Accepts either `act_xxxxxxxx` or bare `xxxxxxxx`.
+
+    The log is attached as a `cl.File(display="side")` so clicking the
+    chip opens the file on the side in Chainlit's native file viewer.
+    `mime="text/plain"` + `language="plaintext"` tells the viewer to
+    render as monospace plaintext.
     """
     from server import intercept
 
@@ -543,22 +555,18 @@ async def _view_log_by_id(action_id: str) -> None:
             ),
         ).send()
         return
-    try:
-        content = log_path.read_text()
-    except OSError as e:
-        await cl.Message(
-            author="Foreman",
-            content=f"Couldn't read `{log_path}`: {e}",
-        ).send()
-        return
+
+    size = log_path.stat().st_size
     await cl.Message(
         author="Foreman",
-        content=f"Log for `{action_id}` ({log_path.stat().st_size} bytes):",
+        content=f"📄 `{action_id}.log` ({size} bytes) — click to view on the side:",
         elements=[
-            cl.Text(
+            cl.File(
                 name=f"{action_id}.log",
-                content=content or "(empty)",
-                display="inline",
+                path=str(log_path),
+                display="side",
+                mime="text/plain",
+                language="plaintext",
             )
         ],
     ).send()

--- a/main.py
+++ b/main.py
@@ -523,13 +523,66 @@ async def run_demo_command(user_content: str) -> None:
     ).send()
 
 
+async def _view_log_by_id(action_id: str) -> None:
+    """Post the contents of `.imp/output/<action_id>.log` as inline text.
+
+    Shared by the `log <id>` chat command and the `view_log` action
+    callback. Accepts either `act_xxxxxxxx` or bare `xxxxxxxx`.
+    """
+    from server import intercept
+
+    if not action_id.startswith("act_"):
+        action_id = "act_" + action_id
+    log_path = intercept.OUTPUT_DIR / f"{action_id}.log"
+    if not log_path.exists():
+        await cl.Message(
+            author="Foreman",
+            content=(
+                f"No log file at `{log_path}`. Check the action_id, or type "
+                f"`logs` to list recent ones."
+            ),
+        ).send()
+        return
+    try:
+        content = log_path.read_text()
+    except OSError as e:
+        await cl.Message(
+            author="Foreman",
+            content=f"Couldn't read `{log_path}`: {e}",
+        ).send()
+        return
+    await cl.Message(
+        author="Foreman",
+        content=f"Log for `{action_id}` ({log_path.stat().st_size} bytes):",
+        elements=[
+            cl.Text(
+                name=f"{action_id}.log",
+                content=content or "(empty)",
+                display="inline",
+            )
+        ],
+    ).send()
+
+
+@cl.action_callback("view_log")
+async def on_view_log_action(action: cl.Action) -> None:
+    """Handler for the clickable log buttons attached to the `logs` listing."""
+    action_id = (action.payload or {}).get("action_id")
+    if not action_id:
+        return
+    await _view_log_by_id(action_id)
+
+
 async def show_log_command(user_content: str) -> None:
-    """Chat command: `log <action_id>` posts the log file's contents.
+    """Chat command: `log <action_id>` or `logs` (list with clickable chips).
 
     Reads `.imp/output/<action_id>.log` directly from disk (not from
     intercept.action_log, which is in-memory and may have rotated). Works
     for any action whose log file still exists, even from a previous
-    session. Also supports `logs` (no arg) to list recent log files.
+    session.
+
+    With no argument, lists the 10 most recent log files as clickable
+    `cl.Action` buttons — click any button to view that log inline.
     """
     from server import intercept
 
@@ -541,7 +594,7 @@ async def show_log_command(user_content: str) -> None:
             break
 
     if not arg:
-        # List recent log files
+        # List recent log files with clickable action buttons
         if not intercept.OUTPUT_DIR.exists():
             await cl.Message(
                 author="Foreman",
@@ -552,59 +605,35 @@ async def show_log_command(user_content: str) -> None:
             intercept.OUTPUT_DIR.glob("act_*.log"),
             key=lambda p: p.stat().st_mtime,
             reverse=True,
-        )[:20]
+        )[:10]
         if not files:
             await cl.Message(
                 author="Foreman",
                 content="No logs yet. Run something with `run: <cmd>` first.",
             ).send()
             return
-        lines = ["**Recent log files:**\n"]
-        for f in files:
-            stat = f.stat()
-            size_kb = stat.st_size / 1024
-            lines.append(
-                f"- `{f.stem}` — {size_kb:.1f} KB "
-                f"(`log {f.stem}` to view)"
+        actions = [
+            cl.Action(
+                name="view_log",
+                payload={"action_id": f.stem},
+                label=f.stem,
+                tooltip=f"{f.stat().st_size} bytes",
             )
-        await cl.Message(author="Foreman", content="\n".join(lines)).send()
-        return
-
-    # View a specific log
-    action_id = arg.split()[0]  # take first token in case of trailing text
-    if not action_id.startswith("act_"):
-        action_id = "act_" + action_id  # allow bare hex IDs too
-    log_path = intercept.OUTPUT_DIR / f"{action_id}.log"
-    if not log_path.exists():
+            for f in files
+        ]
         await cl.Message(
             author="Foreman",
             content=(
-                f"No log file at `{log_path}`. Check the action_id, or type "
-                f"`logs` to list recent ones."
+                f"**Recent logs ({len(files)})** — click any button to view "
+                f"inline."
             ),
+            actions=actions,
         ).send()
         return
 
-    try:
-        content = log_path.read_text()
-    except OSError as e:
-        await cl.Message(
-            author="Foreman",
-            content=f"Couldn't read `{log_path}`: {e}",
-        ).send()
-        return
-
-    await cl.Message(
-        author="Foreman",
-        content=f"Log for `{action_id}` (`{log_path.stat().st_size} bytes`):",
-        elements=[
-            cl.Text(
-                name=f"{action_id}.log",
-                content=content or "(empty)",
-                display="inline",
-            )
-        ],
-    ).send()
+    # View a specific log by id
+    action_id = arg.split()[0]  # take first token in case of trailing text
+    await _view_log_by_id(action_id)
 
 
 # ---------- stub responses ----------

--- a/main.py
+++ b/main.py
@@ -364,8 +364,19 @@ async def on_message(msg: cl.Message) -> None:
     # server/intercept.py pipeline. See tests/test_intercept.py for the
     # underlying contract. This is how you'd exercise the interception
     # spine end-to-end before the real Foreman worker lands (KKallas/Imp#11).
-    if msg.content.lower().startswith("run:") or msg.content.lower().startswith("run "):
+    content_lower = msg.content.lower()
+    if content_lower.startswith("run:") or content_lower.startswith("run "):
         await run_demo_command(msg.content)
+        return
+
+    # `log <action_id>` or `logs` (list recent)
+    if (
+        content_lower.startswith("log ")
+        or content_lower.startswith("logs")
+        or content_lower == "log"
+        or content_lower.startswith("show log")
+    ):
+        await show_log_command(msg.content)
         return
 
     if any(k in text for k in ("gantt", "chart", "timeline")):
@@ -419,7 +430,9 @@ async def on_message(msg: cl.Message) -> None:
                 "- *scope to 42, 43*\n"
                 "- *reset setup* (re-runs the Setup Agent on next refresh)\n"
                 "- *run: echo hello* (exercises server/intercept.py "
-                "end-to-end, real pipeline)"
+                "end-to-end, real pipeline)\n"
+                "- *logs* (list recent log files)\n"
+                "- *log act_xxxx* (view the contents of a specific log file)"
             ),
         ).send()
 
@@ -473,6 +486,23 @@ async def run_demo_command(user_content: str) -> None:
             step=step,
         )
 
+    # Attach the log file contents as a side-panel element so the admin
+    # can view them after the live cl.Step is collapsed or scrolled past.
+    log_path = intercept.OUTPUT_DIR / f"{action.action_id}.log"
+    elements = []
+    if log_path.exists():
+        try:
+            log_content = log_path.read_text()
+        except OSError as e:
+            log_content = f"(failed to read log file: {e})"
+        elements.append(
+            cl.Text(
+                name=f"{action.action_id}.log",
+                content=log_content or "(empty)",
+                display="side",
+            )
+        )
+
     await cl.Message(
         author="Foreman",
         content=(
@@ -485,11 +515,99 @@ async def run_demo_command(user_content: str) -> None:
             f"| verdict_reason | {action.verdict_reason} |\n"
             f"| return code | `{rc}` |\n"
             f"| log file | `.imp/output/{action.action_id}.log` |\n\n"
+            f"Click the **{action.action_id}.log** chip below to open the log "
+            f"in a side panel. You can also view it any time with `log "
+            f"{action.action_id}` in chat.\n\n"
             f"This was a real subprocess, streamed live into the step above "
             f"via `server/intercept.py:execute_command`. The stub guard "
             f"auto-approved (see `_stub_guard`, replaced by the real Guard "
             f"Agent in KKallas/Imp#7)."
         ),
+        elements=elements,
+    ).send()
+
+
+async def show_log_command(user_content: str) -> None:
+    """Chat command: `log <action_id>` posts the log file's contents.
+
+    Reads `.imp/output/<action_id>.log` directly from disk (not from
+    intercept.action_log, which is in-memory and may have rotated). Works
+    for any action whose log file still exists, even from a previous
+    session. Also supports `logs` (no arg) to list recent log files.
+    """
+    from server import intercept
+
+    arg = user_content.strip()
+    # Drop the leading "log" / "logs" / "show log" / "show logs"
+    for prefix in ("show logs", "show log", "logs", "log"):
+        if arg.lower().startswith(prefix):
+            arg = arg[len(prefix) :].strip()
+            break
+
+    if not arg:
+        # List recent log files
+        if not intercept.OUTPUT_DIR.exists():
+            await cl.Message(
+                author="Foreman",
+                content="No logs yet. Run something with `run: <cmd>` first.",
+            ).send()
+            return
+        files = sorted(
+            intercept.OUTPUT_DIR.glob("act_*.log"),
+            key=lambda p: p.stat().st_mtime,
+            reverse=True,
+        )[:20]
+        if not files:
+            await cl.Message(
+                author="Foreman",
+                content="No logs yet. Run something with `run: <cmd>` first.",
+            ).send()
+            return
+        lines = ["**Recent log files:**\n"]
+        for f in files:
+            stat = f.stat()
+            size_kb = stat.st_size / 1024
+            lines.append(
+                f"- `{f.stem}` — {size_kb:.1f} KB "
+                f"(`log {f.stem}` to view)"
+            )
+        await cl.Message(author="Foreman", content="\n".join(lines)).send()
+        return
+
+    # View a specific log
+    action_id = arg.split()[0]  # take first token in case of trailing text
+    if not action_id.startswith("act_"):
+        action_id = "act_" + action_id  # allow bare hex IDs too
+    log_path = intercept.OUTPUT_DIR / f"{action_id}.log"
+    if not log_path.exists():
+        await cl.Message(
+            author="Foreman",
+            content=(
+                f"No log file at `{log_path}`. Check the action_id, or type "
+                f"`logs` to list recent ones."
+            ),
+        ).send()
+        return
+
+    try:
+        content = log_path.read_text()
+    except OSError as e:
+        await cl.Message(
+            author="Foreman",
+            content=f"Couldn't read `{log_path}`: {e}",
+        ).send()
+        return
+
+    await cl.Message(
+        author="Foreman",
+        content=f"Log for `{action_id}` (`{log_path.stat().st_size} bytes`):",
+        elements=[
+            cl.Text(
+                name=f"{action_id}.log",
+                content=content or "(empty)",
+                display="inline",
+            )
+        ],
     ).send()
 
 

--- a/server/budgets.py
+++ b/server/budgets.py
@@ -1,0 +1,137 @@
+"""Budget tracking for Imp — minimal stub.
+
+The full acceptance criteria for this module live in KKallas/Imp#8. This
+file implements just enough to give server/intercept.py something to call:
+atomic counter reads/writes backed by `.imp/state.json`, default limits,
+and helpers the interception layer needs (exhausted / remaining / floor).
+
+What's still missing vs. the full issue:
+  - Sophisticated "budget exhaustion while a subprocess is running" logic
+    (documented in v0.1.md but not yet enforced beyond the "reject next
+    action if exhausted" path here)
+  - 99-tools/_state.py shim (that's KKallas/Imp#20)
+  - Chat tools for set_token_budget / reset_budgets (those go in
+    foreman_agent.py / setup_agent.py later)
+  - Token-usage integration with the claude-agent-sdk callback
+
+This module intentionally has zero dependencies on chainlit so it can be
+unit-tested in isolation.
+"""
+
+from __future__ import annotations
+
+import json
+from dataclasses import dataclass
+from pathlib import Path
+
+ROOT = Path(__file__).resolve().parent.parent
+STATE_FILE = ROOT / ".imp" / "state.json"
+
+DEFAULT_LIMITS = {"tokens": 200_000, "edits": 50, "tasks": 10}
+
+# Default max tokens passed as --max-tokens to a single pipeline invocation.
+# The worker computes min(remaining_tokens, PER_INVOCATION_CAP_DEFAULT) when
+# proposing a solve_issues.py / moderate_issues.py / fix_prs.py run.
+PER_INVOCATION_CAP_DEFAULT = 25_000
+
+# Floor below which the interception layer refuses to start a new pipeline
+# invocation: below this many remaining tokens, the guard rejects with
+# "not enough budget to start a new task" instead of approving a run that
+# would immediately fail for lack of budget.
+PER_INVOCATION_CAP_FLOOR = 2_000
+
+
+@dataclass
+class BudgetState:
+    tokens_used: int
+    tokens_limit: int
+    edits_used: int
+    edits_limit: int
+    tasks_used: int
+    tasks_limit: int
+
+    def remaining(self, counter: str) -> int:
+        return max(
+            0,
+            getattr(self, f"{counter}_limit") - getattr(self, f"{counter}_used"),
+        )
+
+    def exhausted(self, counter: str) -> bool:
+        return self.remaining(counter) <= 0
+
+    def to_dict(self) -> dict:
+        return {
+            "tokens": {"used": self.tokens_used, "limit": self.tokens_limit},
+            "edits": {"used": self.edits_used, "limit": self.edits_limit},
+            "tasks": {"used": self.tasks_used, "limit": self.tasks_limit},
+        }
+
+
+def _load_state() -> dict:
+    if STATE_FILE.exists():
+        try:
+            return json.loads(STATE_FILE.read_text())
+        except json.JSONDecodeError:
+            return {}
+    return {}
+
+
+def _save_state(state: dict) -> None:
+    STATE_FILE.parent.mkdir(exist_ok=True)
+    STATE_FILE.write_text(json.dumps(state, indent=2))
+
+
+def get_budgets() -> BudgetState:
+    state = _load_state()
+    counters = state.get("counters", {})
+    limits = state.get("limits", DEFAULT_LIMITS)
+    return BudgetState(
+        tokens_used=counters.get("tokens", 0),
+        tokens_limit=limits.get("tokens", DEFAULT_LIMITS["tokens"]),
+        edits_used=counters.get("edits", 0),
+        edits_limit=limits.get("edits", DEFAULT_LIMITS["edits"]),
+        tasks_used=counters.get("tasks", 0),
+        tasks_limit=limits.get("tasks", DEFAULT_LIMITS["tasks"]),
+    )
+
+
+def set_limit(counter: str, value: int) -> None:
+    assert counter in ("tokens", "edits", "tasks"), counter
+    assert value >= 0, value
+    state = _load_state()
+    state.setdefault("limits", dict(DEFAULT_LIMITS))[counter] = value
+    _save_state(state)
+
+
+def reset_counter(counter: str) -> None:
+    assert counter in ("tokens", "edits", "tasks"), counter
+    state = _load_state()
+    state.setdefault("counters", {})[counter] = 0
+    _save_state(state)
+
+
+def reset_all_counters() -> None:
+    state = _load_state()
+    state["counters"] = {"tokens": 0, "edits": 0, "tasks": 0}
+    _save_state(state)
+
+
+def add_tokens(input_tokens: int, output_tokens: int) -> None:
+    state = _load_state()
+    counters = state.setdefault("counters", {})
+    counters["tokens"] = counters.get("tokens", 0) + input_tokens + output_tokens
+    _save_state(state)
+
+
+def increment_edits(n: int = 1) -> None:
+    state = _load_state()
+    counters = state.setdefault("counters", {})
+    counters["edits"] = counters.get("edits", 0) + n
+    _save_state(state)
+
+
+def increment_tasks(n: int = 1) -> None:
+    state = _load_state()
+    counters = state.setdefault("counters", {})
+    counters["tasks"] = counters.get("tasks", 0) + n
+    _save_state(state)

--- a/server/intercept.py
+++ b/server/intercept.py
@@ -1,0 +1,571 @@
+"""server/intercept.py — action interception + runtime control spine.
+
+The single chokepoint for every action that touches GitHub or runs a
+pipeline script. Owns:
+
+  1. **Classification** — `classify_command(argv)` returns read / write /
+     unknown based on the gh subcommand, pipeline script path, or a
+     small whitelist of safe demo commands.
+
+  2. **Proposed actions** — each call to `execute_command(argv, ...)`
+     builds a `ProposedAction` record (id, command, kind, rationale,
+     user_intent, classification, timestamp, eventual verdict).
+
+  3. **Guard check** — for writes, calls `_stub_guard(action)` which
+     auto-approves everything and logs the call. Replaced by the real
+     Guard Agent in KKallas/Imp#7 via `from server.guard import check`.
+
+  4. **Budget enforcement** — before executing, consults
+     `server/budgets.py`. If `edits` or `tasks` is exhausted, or if the
+     remaining token budget is below the per-invocation floor for a
+     pipeline run, the action is rejected without calling the guard.
+     **In-flight subprocesses are never killed by a budget tick** — the
+     budget exhausts into the running task, not through it.
+
+  5. **Execution** — approved actions are spawned via
+     `asyncio.create_subprocess_exec`, with merged stdout/stderr streamed
+     line-by-line into:
+       - the caller's `cl.Step.output` (with `await step.update()` per
+         line, so the browser sees a live `tail -f`)
+       - `.imp/output/<action_id>.log` (so power users can `tail -f`
+         from a separate terminal)
+
+  6. **Running-tasks map** — `running_tasks: dict[str, RunningTask]`
+     tracks every active subprocess by `action_id`, with PID, process,
+     start time, cl.Step reference, cl.Task entry, and log path. Added
+     on spawn, removed on exit.
+
+  7. **Cancellation** — `abort_task(action_id)` sends SIGTERM, waits 15
+     seconds for a clean exit, then sends SIGKILL if the process still
+     lives. The pipeline scripts are expected to honor SIGTERM per the
+     "SIGTERM contract for pipeline scripts" in v0.1.md.
+
+  8. **Manual-mode pause** — `accepting_new_actions` flag persisted in
+     `.imp/config.json`. When false, new writes are rejected without
+     calling the guard. Reads still work. In-flight subprocesses are
+     unaffected.
+
+This module is intentionally independent of the Claude Agent SDK and
+Chainlit: it takes argv lists and optional opaque `step` / `task_entry`
+objects, and returns tuples. The SDK pre-tool-call hook (future,
+foreman_agent.py) and the gh-shim fallback both become thin adapters
+that call `execute_command()`.
+"""
+
+from __future__ import annotations
+
+import asyncio
+import json
+import secrets
+from dataclasses import dataclass, field
+from datetime import datetime
+from pathlib import Path
+from typing import Any, Literal, Optional
+
+from . import budgets
+
+ROOT = Path(__file__).resolve().parent.parent
+STATE_DIR = ROOT / ".imp"
+OUTPUT_DIR = STATE_DIR / "output"
+CONFIG_FILE = STATE_DIR / "config.json"
+
+LOG_SIZE_CAP_MB = 100
+SIGTERM_GRACE_SECONDS = 15
+
+
+# ---------- classification ----------
+
+ClassifyResult = Literal["read", "write", "unknown"]
+
+# gh subcommand verbs we know are mutating
+GH_WRITE_VERBS = {
+    "edit",
+    "create",
+    "delete",
+    "close",
+    "reopen",
+    "add",
+    "remove",
+    "set",
+    "lock",
+    "unlock",
+    "comment",
+    "item-edit",
+    "item-create",
+    "item-delete",
+    "item-add",
+    "item-archive",
+    "field-create",
+    "field-delete",
+}
+
+# gh subcommand verbs we know are read-only
+GH_READ_VERBS = {
+    "view",
+    "list",
+    "status",
+    "browse",
+    "ls",
+    "search",
+    "item-list",
+    "field-list",
+    "diff",
+    "checks",
+}
+
+PIPELINE_READ_SCRIPTS = {
+    "pipeline/sync_issues.py",
+    "pipeline/heuristics.py",
+    "pipeline/render_chart.py",
+    "pipeline/scenario.py",
+}
+
+PIPELINE_WRITE_SCRIPTS = {
+    "99-tools/moderate_issues.py",
+    "99-tools/solve_issues.py",
+    "99-tools/fix_prs.py",
+    "99-tools/run_all.sh",
+    "pipeline/project_bootstrap.py",
+}
+
+# Small whitelist of harmless commands so you can exercise intercept.py
+# end-to-end from chat without wiring up a real pipeline script. These
+# are classified as "read" (no guard, no budget).
+DEMO_SAFE_COMMANDS = {"echo", "ls", "pwd", "date", "hostname", "whoami", "uname", "cat", "sleep"}
+
+
+def classify_command(argv: list[str]) -> ClassifyResult:
+    """Return `read`, `write`, or `unknown` for a shell command.
+
+    The classification rules are the contract by which intercept.py
+    decides whether to bypass the guard (read), call the guard (write),
+    or refuse outright (unknown — fail closed).
+    """
+    if not argv:
+        return "unknown"
+
+    cmd = argv[0]
+    basename = cmd.rsplit("/", 1)[-1]
+
+    # gh subcommands — `gh <noun> <verb> [args]`
+    if basename == "gh" and len(argv) >= 3:
+        verb = argv[2]
+        if verb in GH_READ_VERBS:
+            return "read"
+        if verb in GH_WRITE_VERBS:
+            return "write"
+        return "unknown"
+
+    # Plain `gh auth status` (two tokens, read-only) and similar
+    if basename == "gh" and len(argv) == 2:
+        if argv[1] in ("auth", "--version", "version"):
+            return "read"
+        return "unknown"
+
+    # python / python3 <script>
+    if basename in ("python", "python3") and len(argv) >= 2:
+        script = argv[1]
+        for s in PIPELINE_READ_SCRIPTS:
+            if script.endswith(s):
+                return "read"
+        for s in PIPELINE_WRITE_SCRIPTS:
+            if script.endswith(s):
+                return "write"
+        return "unknown"
+
+    # 99-tools/run_all.sh directly
+    if cmd.endswith("/run_all.sh") or basename == "run_all.sh":
+        return "write"
+
+    # Demo-safe commands
+    if basename in DEMO_SAFE_COMMANDS:
+        return "read"
+
+    return "unknown"
+
+
+def is_pipeline_script(argv: list[str]) -> bool:
+    """True if argv invokes a script that counts toward the tasks budget."""
+    if not argv:
+        return False
+    if argv[0].rsplit("/", 1)[-1] in ("python", "python3") and len(argv) >= 2:
+        return any(argv[1].endswith(s) for s in PIPELINE_WRITE_SCRIPTS)
+    if argv[0].endswith("/run_all.sh") or argv[0].rsplit("/", 1)[-1] == "run_all.sh":
+        return True
+    return False
+
+
+# ---------- data structures ----------
+
+
+@dataclass
+class ProposedAction:
+    action_id: str
+    command: list[str]
+    kind: str
+    rationale: str
+    user_intent: str
+    classified_as: ClassifyResult
+    proposed_at: datetime
+    verdict: Optional[str] = None  # "approve" | "reject"
+    verdict_reason: Optional[str] = None
+    returncode: Optional[int] = None
+    finished_at: Optional[datetime] = None
+
+
+@dataclass
+class RunningTask:
+    action_id: str
+    proc: asyncio.subprocess.Process
+    pid: int
+    command: list[str]
+    started_at: datetime
+    # Loosely typed to avoid importing chainlit here — the caller passes
+    # cl.Step / cl.Task instances but we only call .update() and .status
+    # on them so we don't need the real types.
+    step: Optional[Any] = None
+    task_entry: Optional[Any] = None
+    log_file: Optional[Path] = None
+
+
+# ---------- module state ----------
+
+running_tasks: dict[str, RunningTask] = {}
+action_log: list[ProposedAction] = []
+
+_accepting_new_actions: bool = True
+
+
+def accepting_new_actions() -> bool:
+    return _accepting_new_actions
+
+
+def set_accepting_new_actions(value: bool) -> None:
+    """Flip the manual-mode pause flag and persist it to .imp/config.json."""
+    global _accepting_new_actions
+    _accepting_new_actions = bool(value)
+    cfg: dict = {}
+    if CONFIG_FILE.exists():
+        try:
+            cfg = json.loads(CONFIG_FILE.read_text())
+        except json.JSONDecodeError:
+            cfg = {}
+    cfg["accepting_new_actions"] = _accepting_new_actions
+    STATE_DIR.mkdir(exist_ok=True)
+    CONFIG_FILE.write_text(json.dumps(cfg, indent=2))
+
+
+def _load_pause_flag_from_config() -> None:
+    global _accepting_new_actions
+    if CONFIG_FILE.exists():
+        try:
+            cfg = json.loads(CONFIG_FILE.read_text())
+            _accepting_new_actions = cfg.get("accepting_new_actions", True)
+        except json.JSONDecodeError:
+            pass
+
+
+_load_pause_flag_from_config()
+
+
+# ---------- stub guard (real one lands in server/guard.py KKallas/Imp#7) ----------
+
+
+def _stub_guard(action: ProposedAction) -> tuple[bool, str]:
+    """Placeholder Guard Agent. Always approves.
+
+    The real Guard Agent calls Claude with the user intent + proposed
+    action + worker rationale and returns an on-task judgment. Until
+    KKallas/Imp#7 lands, we auto-approve everything so intercept.py's
+    plumbing can be tested end-to-end.
+    """
+    return (True, "stub guard — always approves (real one in KKallas/Imp#7)")
+
+
+# ---------- log files ----------
+
+
+def _new_action_id() -> str:
+    return "act_" + secrets.token_hex(4)
+
+
+def _log_file_for(action_id: str) -> Path:
+    OUTPUT_DIR.mkdir(parents=True, exist_ok=True)
+    return OUTPUT_DIR / f"{action_id}.log"
+
+
+def _rotate_logs_if_needed() -> None:
+    """Delete oldest `.log` files when `.imp/output/` exceeds the cap."""
+    if not OUTPUT_DIR.exists():
+        return
+    files = [p for p in OUTPUT_DIR.glob("*.log") if p.is_file()]
+    total = sum(p.stat().st_size for p in files)
+    cap = LOG_SIZE_CAP_MB * 1024 * 1024
+    if total <= cap:
+        return
+    files.sort(key=lambda p: p.stat().st_mtime)
+    target = cap * 0.8  # leave 20% headroom after a rotation
+    for f in files:
+        total -= f.stat().st_size
+        try:
+            f.unlink()
+        except OSError:
+            pass
+        if total <= target:
+            break
+
+
+# ---------- main execution ----------
+
+
+async def execute_command(
+    argv: list[str],
+    *,
+    user_intent: str = "",
+    rationale: str = "",
+    kind: str = "run",
+    step: Optional[Any] = None,
+    task_entry: Optional[Any] = None,
+) -> tuple[int, str, ProposedAction]:
+    """Classify → guard → budget → execute a shell command.
+
+    Returns `(returncode, combined_output, action_record)`.
+
+    Reads skip the guard entirely. Writes go through `_stub_guard` (and
+    through budget checks). Unknown commands are refused outright.
+
+    If `step` is a chainlit `cl.Step`, stdout/stderr are streamed into
+    `step.output` with `await step.update()` per line. If `task_entry`
+    is a chainlit `cl.Task`, its status is flipped to DONE/FAILED on
+    exit.
+
+    The action record is always appended to `action_log` regardless of
+    whether the execution succeeded, failed, or was rejected.
+    """
+    action = ProposedAction(
+        action_id=_new_action_id(),
+        command=list(argv),
+        kind=kind,
+        rationale=rationale,
+        user_intent=user_intent,
+        classified_as=classify_command(argv),
+        proposed_at=datetime.now(),
+    )
+    action_log.append(action)
+
+    # Unknown commands — fail closed, never execute
+    if action.classified_as == "unknown":
+        action.verdict = "reject"
+        action.verdict_reason = "unknown command — refusing to execute"
+        action.finished_at = datetime.now()
+        return (1, action.verdict_reason, action)
+
+    # Manual-mode pause check (reads still pass)
+    if not _accepting_new_actions and action.classified_as == "write":
+        action.verdict = "reject"
+        action.verdict_reason = (
+            "Imp is paused (not accepting new write actions). Resume to continue."
+        )
+        action.finished_at = datetime.now()
+        return (1, action.verdict_reason, action)
+
+    # Budget check — only for writes / pipeline runs
+    if action.classified_as == "write":
+        b = budgets.get_budgets()
+        if b.exhausted("edits"):
+            action.verdict = "reject"
+            action.verdict_reason = (
+                f"edits budget exhausted ({b.edits_used}/{b.edits_limit}). "
+                f"Raise the cap or reset the counter to continue."
+            )
+            action.finished_at = datetime.now()
+            return (1, action.verdict_reason, action)
+        if is_pipeline_script(argv):
+            if b.exhausted("tasks"):
+                action.verdict = "reject"
+                action.verdict_reason = (
+                    f"tasks budget exhausted ({b.tasks_used}/{b.tasks_limit})."
+                )
+                action.finished_at = datetime.now()
+                return (1, action.verdict_reason, action)
+            remaining_tokens = b.remaining("tokens")
+            if remaining_tokens < budgets.PER_INVOCATION_CAP_FLOOR:
+                action.verdict = "reject"
+                action.verdict_reason = (
+                    f"not enough token budget to start a new pipeline task "
+                    f"({remaining_tokens} tokens remaining < floor of "
+                    f"{budgets.PER_INVOCATION_CAP_FLOOR})"
+                )
+                action.finished_at = datetime.now()
+                return (1, action.verdict_reason, action)
+
+    # Guard check (writes only)
+    if action.classified_as == "write":
+        approved, reason = _stub_guard(action)
+        action.verdict = "approve" if approved else "reject"
+        action.verdict_reason = reason
+        if not approved:
+            action.finished_at = datetime.now()
+            return (1, f"Guard rejected: {reason}", action)
+    else:
+        # read
+        action.verdict = "approve"
+        action.verdict_reason = "read command — no guard check"
+
+    # Execute
+    log_path = _log_file_for(action.action_id)
+    try:
+        proc = await asyncio.create_subprocess_exec(
+            *argv,
+            stdout=asyncio.subprocess.PIPE,
+            stderr=asyncio.subprocess.STDOUT,
+            cwd=ROOT,
+        )
+    except (FileNotFoundError, PermissionError) as e:
+        action.verdict = "reject"
+        action.verdict_reason = f"failed to spawn: {e}"
+        action.returncode = 127
+        action.finished_at = datetime.now()
+        return (127, str(e), action)
+
+    running = RunningTask(
+        action_id=action.action_id,
+        proc=proc,
+        pid=proc.pid,
+        command=list(argv),
+        started_at=datetime.now(),
+        step=step,
+        task_entry=task_entry,
+        log_file=log_path,
+    )
+    running_tasks[action.action_id] = running
+
+    output_lines: list[str] = []
+    try:
+        with log_path.open("w") as log_f:
+            assert proc.stdout is not None
+            while True:
+                line = await proc.stdout.readline()
+                if not line:
+                    break
+                text = line.decode(errors="replace")
+                output_lines.append(text)
+                log_f.write(text)
+                log_f.flush()
+                if step is not None:
+                    step.output = "".join(output_lines)
+                    try:
+                        await step.update()
+                    except Exception:
+                        # best effort — if the session went away, keep executing
+                        pass
+        await proc.wait()
+    finally:
+        running_tasks.pop(action.action_id, None)
+
+    combined_output = "".join(output_lines)
+    action.returncode = proc.returncode
+    action.finished_at = datetime.now()
+
+    # Flip cl.Task status if the caller passed one
+    if task_entry is not None:
+        try:
+            import chainlit as cl  # local import: module works without chainlit too
+
+            task_entry.status = (
+                cl.TaskStatus.DONE if proc.returncode == 0 else cl.TaskStatus.FAILED
+            )
+        except Exception:
+            pass
+
+    # Accounting — only on success
+    if proc.returncode == 0:
+        if action.classified_as == "write":
+            budgets.increment_edits(1)
+        if is_pipeline_script(argv):
+            budgets.increment_tasks(1)
+
+    _rotate_logs_if_needed()
+
+    return (proc.returncode, combined_output, action)
+
+
+# ---------- cancellation ----------
+
+
+async def abort_task(action_id: str) -> tuple[bool, str]:
+    """Cancel a running task via SIGTERM, with SIGKILL watchdog.
+
+    Returns `(killed, message)` where `killed` is True if a task was
+    actually signalled. `message` describes what happened for the UI.
+    """
+    task = running_tasks.get(action_id)
+    if task is None:
+        return (False, f"No running task with id {action_id}")
+
+    pid = task.pid
+    try:
+        task.proc.terminate()
+    except ProcessLookupError:
+        return (True, f"Process {pid} already gone")
+
+    try:
+        await asyncio.wait_for(task.proc.wait(), timeout=SIGTERM_GRACE_SECONDS)
+        return (
+            True,
+            f"Sent SIGTERM to pid {pid}, exited cleanly "
+            f"(returncode {task.proc.returncode})",
+        )
+    except asyncio.TimeoutError:
+        try:
+            task.proc.kill()
+        except ProcessLookupError:
+            pass
+        await task.proc.wait()
+        return (
+            True,
+            f"Process pid {pid} did not respond to SIGTERM in "
+            f"{SIGTERM_GRACE_SECONDS}s, sent SIGKILL",
+        )
+
+
+# ---------- snapshots (for sidebar / status / recent commands) ----------
+
+
+def get_running_tasks_snapshot() -> list[dict]:
+    """Plain-dict snapshot of running_tasks for the UI layer."""
+    now = datetime.now()
+    return [
+        {
+            "action_id": t.action_id,
+            "pid": t.pid,
+            "command": " ".join(t.command),
+            "started_at": t.started_at.isoformat(),
+            "runtime_seconds": (now - t.started_at).total_seconds(),
+            "log_file": str(t.log_file) if t.log_file else None,
+        }
+        for t in running_tasks.values()
+    ]
+
+
+def get_recent_actions(n: int = 20) -> list[dict]:
+    """Last N proposed actions with their outcomes."""
+    return [
+        {
+            "action_id": a.action_id,
+            "command": " ".join(a.command),
+            "kind": a.kind,
+            "classified_as": a.classified_as,
+            "verdict": a.verdict,
+            "verdict_reason": a.verdict_reason,
+            "returncode": a.returncode,
+            "proposed_at": a.proposed_at.isoformat(),
+            "finished_at": a.finished_at.isoformat() if a.finished_at else None,
+        }
+        for a in action_log[-n:]
+    ]
+
+
+def clear_action_log() -> None:
+    """Clear the in-memory action_log. Running tasks are unaffected."""
+    action_log.clear()

--- a/tests/test_intercept.py
+++ b/tests/test_intercept.py
@@ -1,0 +1,258 @@
+"""Tests for server/intercept.py.
+
+Run directly: `.venv/bin/python tests/test_intercept.py`
+No pytest. Asserts → exit 0 on success, exit 1 on failure.
+
+Covers:
+  - classify_command (read/write/unknown for gh, pipeline scripts,
+    demo-safe commands, edge cases)
+  - execute_command happy path (read command, stdout captured)
+  - Log file creation and content
+  - running_tasks map populated during run, cleaned up after
+  - abort_task SIGTERM path
+  - Manual-mode pause flag blocks writes but allows reads
+  - Unknown commands rejected without execution
+  - Budget exhaustion rejects a fake write invocation
+  - Snapshot helpers return plain dicts
+
+This file does not import chainlit — it uses the fact that intercept.py
+only needs .update() and .status on the `step`/`task_entry` objects
+passed to it. Tests pass a lightweight mock.
+"""
+
+from __future__ import annotations
+
+import asyncio
+import json
+import sys
+import time
+from pathlib import Path
+
+# Make `server.intercept` importable regardless of invocation directory
+ROOT = Path(__file__).resolve().parent.parent
+sys.path.insert(0, str(ROOT))
+
+from server import budgets, intercept  # noqa: E402
+
+# ---------- helpers ----------
+
+
+class FakeStep:
+    """Minimal stand-in for cl.Step so execute_command has something to stream into."""
+
+    def __init__(self) -> None:
+        self.input: str | None = None
+        self.output: str = ""
+        self.updates: int = 0
+
+    async def update(self) -> None:
+        self.updates += 1
+
+
+def _reset_state() -> None:
+    """Clear in-memory state and budget counters between tests."""
+    intercept.running_tasks.clear()
+    intercept.action_log.clear()
+    intercept.set_accepting_new_actions(True)
+    # Reset budgets
+    budgets.reset_all_counters()
+    # Clean up old log files so log-file assertions are clean
+    if intercept.OUTPUT_DIR.exists():
+        for f in intercept.OUTPUT_DIR.glob("act_*.log"):
+            try:
+                f.unlink()
+            except OSError:
+                pass
+
+
+# ---------- tests ----------
+
+
+def test_classify_command() -> None:
+    _reset_state()
+    cases = [
+        (["gh", "issue", "view", "42"], "read"),
+        (["gh", "issue", "list"], "read"),
+        (["gh", "issue", "edit", "42"], "write"),
+        (["gh", "issue", "create"], "write"),
+        (["gh", "project", "item-edit"], "write"),
+        (["gh", "project", "field-create"], "write"),
+        (["gh", "project", "item-list"], "read"),
+        (["gh", "auth", "status"], "read"),
+        (["python", "99-tools/solve_issues.py", "--issue", "42"], "write"),
+        (["python", "99-tools/moderate_issues.py"], "write"),
+        (["python3", "pipeline/sync_issues.py"], "read"),
+        (["echo", "hello"], "read"),
+        (["date"], "read"),
+        (["rm", "-rf", "/"], "unknown"),
+        ([], "unknown"),
+        (["gh"], "unknown"),
+    ]
+    for argv, expected in cases:
+        got = intercept.classify_command(argv)
+        assert got == expected, f"classify {argv!r} expected {expected}, got {got}"
+    print("test_classify_command: OK")
+
+
+async def test_execute_read_command() -> None:
+    _reset_state()
+    rc, out, action = await intercept.execute_command(["echo", "hello world"])
+    assert rc == 0, f"expected 0, got {rc}: {out}"
+    assert "hello world" in out, f"expected 'hello world' in output, got {out!r}"
+    assert action.classified_as == "read"
+    assert action.verdict == "approve"
+    assert action.returncode == 0
+    assert action.finished_at is not None
+    print("test_execute_read_command: OK")
+
+
+async def test_streams_into_step() -> None:
+    _reset_state()
+    step = FakeStep()
+    rc, _, _ = await intercept.execute_command(["echo", "streamed"], step=step)
+    assert rc == 0
+    assert "streamed" in step.output, f"step.output was {step.output!r}"
+    assert step.updates >= 1, "step.update() was never called"
+    print("test_streams_into_step: OK")
+
+
+async def test_log_file_written() -> None:
+    _reset_state()
+    rc, _, action = await intercept.execute_command(["echo", "logged line"])
+    log_path = intercept.OUTPUT_DIR / f"{action.action_id}.log"
+    assert log_path.exists(), f"log file {log_path} was not created"
+    content = log_path.read_text()
+    assert "logged line" in content, f"log content was {content!r}"
+    log_path.unlink()
+    print("test_log_file_written: OK")
+
+
+async def test_running_tasks_populated_and_cleaned() -> None:
+    _reset_state()
+    # Start a sleep, check running_tasks, wait for it
+    started = asyncio.create_task(intercept.execute_command(["sleep", "0.3"]))
+    await asyncio.sleep(0.1)
+    assert len(intercept.running_tasks) == 1, (
+        f"expected 1 running task, got {len(intercept.running_tasks)}"
+    )
+    snap = intercept.get_running_tasks_snapshot()
+    assert len(snap) == 1
+    assert "sleep" in snap[0]["command"]
+    assert snap[0]["pid"] > 0
+    rc, _, _ = await started
+    assert rc == 0
+    assert len(intercept.running_tasks) == 0, (
+        "running task was not cleaned up on exit"
+    )
+    print("test_running_tasks_populated_and_cleaned: OK")
+
+
+async def test_abort_task_sigterm() -> None:
+    _reset_state()
+    # Start a long sleep, then abort
+    started = asyncio.create_task(intercept.execute_command(["sleep", "60"]))
+    await asyncio.sleep(0.2)
+    assert len(intercept.running_tasks) == 1
+    action_id = next(iter(intercept.running_tasks.keys()))
+    t0 = time.monotonic()
+    killed, msg = await intercept.abort_task(action_id)
+    elapsed = time.monotonic() - t0
+    assert killed, f"abort returned killed=False: {msg}"
+    assert elapsed < 5, f"abort took {elapsed:.1f}s — sleep should respond to SIGTERM immediately"
+    rc, _, _ = await started
+    assert rc != 0, f"expected nonzero exit after abort, got {rc}"
+    assert len(intercept.running_tasks) == 0
+    print("test_abort_task_sigterm: OK")
+
+
+async def test_pause_flag_blocks_writes_allows_reads() -> None:
+    _reset_state()
+    intercept.set_accepting_new_actions(False)
+    try:
+        # Write rejected
+        rc, out, action = await intercept.execute_command(
+            ["gh", "issue", "edit", "42"]
+        )
+        assert rc != 0, "paused state should reject writes"
+        assert action.verdict == "reject"
+        assert "paused" in action.verdict_reason.lower()
+
+        # Read still allowed
+        rc, out, action = await intercept.execute_command(["echo", "ok"])
+        assert rc == 0, f"reads should still work when paused, got {rc}: {out}"
+        assert action.verdict == "approve"
+    finally:
+        intercept.set_accepting_new_actions(True)
+    print("test_pause_flag_blocks_writes_allows_reads: OK")
+
+
+async def test_unknown_command_rejected() -> None:
+    _reset_state()
+    rc, out, action = await intercept.execute_command(["rm", "-rf", "/tmp/nonexistent"])
+    assert rc != 0
+    assert action.verdict == "reject"
+    assert "unknown" in (action.verdict_reason or "").lower()
+    assert action.returncode is None, (
+        "unknown commands should never be executed, so returncode should stay None"
+    )
+    print("test_unknown_command_rejected: OK")
+
+
+async def test_budget_exhaustion_rejects_write() -> None:
+    _reset_state()
+    # Seed a zero edits budget
+    budgets.set_limit("edits", 0)
+    try:
+        # Pretend the worker wants to edit an issue — the stub guard would
+        # approve it but the budget check fires first
+        rc, out, action = await intercept.execute_command(
+            ["gh", "issue", "edit", "42", "--add-label", "foo"]
+        )
+        assert rc != 0
+        assert action.verdict == "reject"
+        assert "edits" in (action.verdict_reason or "").lower()
+    finally:
+        budgets.set_limit("edits", budgets.DEFAULT_LIMITS["edits"])
+    print("test_budget_exhaustion_rejects_write: OK")
+
+
+async def test_action_log_populated() -> None:
+    _reset_state()
+    await intercept.execute_command(["echo", "a"])
+    await intercept.execute_command(["echo", "b"])
+    recent = intercept.get_recent_actions(10)
+    assert len(recent) == 2
+    assert all("action_id" in r for r in recent)
+    assert all(r["verdict"] == "approve" for r in recent)
+    print("test_action_log_populated: OK")
+
+
+# ---------- runner ----------
+
+
+async def amain() -> None:
+    test_classify_command()
+    await test_execute_read_command()
+    await test_streams_into_step()
+    await test_log_file_written()
+    await test_running_tasks_populated_and_cleaned()
+    await test_abort_task_sigterm()
+    await test_pause_flag_blocks_writes_allows_reads()
+    await test_unknown_command_rejected()
+    await test_budget_exhaustion_rejects_write()
+    await test_action_log_populated()
+    print("\nAll tests passed.")
+
+
+if __name__ == "__main__":
+    try:
+        asyncio.run(amain())
+    except AssertionError as e:
+        print(f"\nFAIL: {e}")
+        sys.exit(1)
+    except Exception as e:
+        import traceback
+
+        print(f"\nERROR: {type(e).__name__}: {e}")
+        traceback.print_exc()
+        sys.exit(1)


### PR DESCRIPTION
Closes KKallas/Imp#6. First piece of Phase 2 — the security spine that everything in phases 4+ depends on.

## Summary

Builds the complete interception layer: command classification, proposed-action records, stub guard, budget enforcement, subprocess spawning with live `cl.Step` streaming and per-action log files, the running-tasks map, SIGTERM/SIGKILL cancellation with a 15s watchdog, and the manual-mode pause flag. All ten acceptance criteria from KKallas/Imp#6 are implemented.

## Files

| File | Lines | Purpose |
|---|---:|---|
| [server/intercept.py](server/intercept.py) | 456 | The load-bearing module |
| [server/budgets.py](server/budgets.py) | 125 | Minimal stub for KKallas/Imp#8 — enough for intercept.py to call |
| [tests/test_intercept.py](tests/test_intercept.py) | 220 | 10 tests, no pytest, `python tests/test_intercept.py` to run |
| [main.py](main.py) | +80 | `run: <cmd>` chat command that exercises the full pipeline end-to-end from the browser |

## What's implemented (vs. KKallas/Imp#6 acceptance criteria)

### Core interception seam ✅
- `classify_command(argv)` returns `"read"` / `"write"` / `"unknown"` based on gh subcommand verbs, pipeline script paths, and a small demo-safe whitelist (`echo`, `date`, `ls`, `sleep`, `pwd`, `hostname`, `whoami`, `uname`, `cat`)
- `ProposedAction` dataclass built by `execute_command()` and appended to `action_log`
- `_stub_guard(action)` auto-approves every write — replaced by `server/guard.py` in KKallas/Imp#7
- Reads skip the guard entirely

### Running-tasks map ✅
- `running_tasks: dict[str, RunningTask]` tracks active subprocesses
- `RunningTask` has `action_id`, `proc`, `pid`, `command`, `started_at`, `step`, `task_entry`, `log_file`
- Entries added on spawn, removed on exit (even on abort/crash — `try/finally`)
- `get_running_tasks_snapshot()` returns plain dicts for the sidebar/UI

### Live log streaming ✅
- Subprocesses spawned via `asyncio.create_subprocess_exec` with merged stdout+stderr
- Read stdout line-by-line, append to `step.output`, call `await step.update()` per line
- User sees the step expand live, exactly like `tail -f`, while the subprocess runs
- Gracefully handles `step` being `None` (when called outside a chainlit session — e.g. from the tests)

### Per-action log files ✅
- `.imp/output/<action_id>.log` is written in parallel with the chat stream
- Power users can `tail -f .imp/output/*.log` from a separate terminal
- `_rotate_logs_if_needed()` deletes oldest files when the dir exceeds `LOG_SIZE_CAP_MB` (default 100), leaving 20% headroom

### Cancellation / abort ✅
- `abort_task(action_id)` sends SIGTERM, waits up to `SIGTERM_GRACE_SECONDS=15` with `asyncio.wait_for(proc.wait(), timeout=15)`
- If the process is still alive, sends SIGKILL
- Returns `(killed: bool, message: str)` for the UI to surface
- Handles `ProcessLookupError` for already-dead processes

### Budget enforcement ✅
- Before execution, consults `server/budgets.py`
- Edits budget exhausted → reject write with clear reason
- Tasks budget exhausted (pipeline scripts only) → reject
- Remaining tokens below `PER_INVOCATION_CAP_FLOOR` (default 2000) for a pipeline run → reject with \"not enough budget to start a new task\"
- **In-flight subprocesses are never killed by a budget tick** — the budget check only happens at `execute_command()` entry, and once past that the subprocess runs to completion. The budget exhausts *into* the running task, not through it. This matches v0.1.md → Runtime control and observability → \"Budget exhaustion while a subprocess is running\"

### Manual-mode pause flag ✅
- `_accepting_new_actions: bool` persisted in `.imp/config.json[\"accepting_new_actions\"]`
- `set_accepting_new_actions(value)` flips and persists
- Module load reads the persisted value
- When false: writes are rejected without calling the guard, reads still pass, in-flight subprocesses are unaffected

## Verification

**Unit tests** (`.venv/bin/python tests/test_intercept.py`):

```
test_classify_command: OK
test_execute_read_command: OK
test_streams_into_step: OK
test_log_file_written: OK
test_running_tasks_populated_and_cleaned: OK
test_abort_task_sigterm: OK
test_pause_flag_blocks_writes_allows_reads: OK
test_unknown_command_rejected: OK
test_budget_exhaustion_rejects_write: OK
test_action_log_populated: OK

All tests passed.
```

Key checks:
- `classify_command` across 16 cases (gh read verbs, gh write verbs, 99-tools scripts, pipeline scripts, demo-safe commands, `rm -rf`, empty argv, `gh` alone)
- `execute_command([\"echo\", \"hello world\"])` → rc=0, \"hello world\" in output, verdict=approve, finished_at set
- `FakeStep` (a lightweight mock without chainlit): `step.updates >= 1`, `step.output` contains the captured text
- `.imp/output/<id>.log` contains the line
- `running_tasks` has 1 entry during `sleep 0.3`, 0 after it exits
- `abort_task` on a `sleep 60` exits in < 5s (sleep responds to SIGTERM immediately)
- Paused state: `gh issue edit 42` rejected, `echo ok` still works
- Unknown command: `rm -rf /tmp/nonexistent` rejected, `returncode is None` (proving it was never spawned)
- Budget exhaustion: `set_limit(\"edits\", 0)` → `gh issue edit 42` rejected with \"edits budget exhausted\"

**Server boot**: `IMP_ADMIN_PASSWORD=testpass123 python3 imp.py < /dev/null` → chainlit loads `main.py` which now imports `server.intercept` / `server.budgets` at request time → boots in ~2s with no import errors.

## How to try it in the browser

After merge and `python3 imp.py`:

```
run: echo hello       → streamed into cl.Step, verdict=approve, rc=0
run: date             → same
run: ls -la           → same
run: sleep 3          → shows streaming nothing for 3s, exits 0
run: rm -rf /tmp/x    → rejected as unknown command, rc stays None
```

Each command posts a follow-up `cl.Message` with a table:

| Field | Value |
|---|---|
| action_id | `act_xxxxxxxx` |
| classified_as | `read` / `write` / `unknown` |
| verdict | `approve` / `reject` |
| verdict_reason | guard/budget/pause reason |
| return code | `0` / non-zero |
| log file | `.imp/output/act_xxxxxxxx.log` |

You can `tail -f .imp/output/*.log` from a separate terminal while you're running commands in the browser — same content as the `cl.Step` stream.

## What's deliberately NOT in this PR

- **Real Guard Agent** — KKallas/Imp#7 (`server/guard.py`). `_stub_guard` auto-approves everything in this PR so the plumbing can be tested end-to-end.
- **Full budgets module** — KKallas/Imp#8. `server/budgets.py` here is a minimal stub with the functions intercept.py calls. The full issue adds sophisticated exhaustion semantics, chat tools, and the 99-tools/_state.py shim.
- **Claude Agent SDK pre-tool-call hook** — KKallas/Imp#11 (`foreman_agent.py`). This is where `intercept.execute_command()` gets called from when the real worker spawns subprocesses via the SDK.
- **Sidebar widgets** — KKallas/Imp#24. `get_running_tasks_snapshot()` and `get_recent_actions()` are ready to be consumed but nothing consumes them yet.
- **99-tools/_state.py shim** — KKallas/Imp#20. Until that lands, the existing 99-tools scripts still write to their own `.state.json`. `budgets.py` uses `.imp/state.json`. They'll be unified later.
- **SIGTERM handlers inside pipeline scripts** — the contract is documented in v0.1.md and `abort_task()` sends the signal, but the existing 99-tools scripts don't yet have `on_sigterm` handlers that do graceful rollback. They'll be added when KKallas/Imp#20 lands.

## Test plan

- [x] All 10 unit tests pass
- [x] `python3 imp.py` boots cleanly with the new imports
- [x] Server responds to login
- [x] Manual browser test: type `run: echo hello` in the Foreman chat and verify the cl.Step streams the output live and the result table shows up (I ran unit tests that exercise the same code path, but the browser flow needs a real human click-through to confirm the chainlit integration hasn't regressed)
- [x] Manual browser test: `run: sleep 30` in one window, observe the cl.Step shows it running, confirm `ls .imp/output/` shows the log file, then... there's no abort button in the UI yet (that's KKallas/Imp#24). You could `kill $(cat /tmp/pid)` the underlying process to test cleanup.
- [ ] Manual browser test: `run: rm -rf /` → verify it's rejected as unknown