### PR TITLE
[P2.9c] dispatcher: cl.Step spinner around synthesis call

### DIFF
--- a/main.py
+++ b/main.py
@@ -42,6 +42,7 @@ import asyncio
 import json
 import re
 import subprocess
+from contextlib import asynccontextmanager
 from pathlib import Path
 
 import chainlit as cl
@@ -734,6 +735,7 @@ async def _on_message_body(msg: cl.Message) -> None:
         msg.content,
         say=_foreman_say,
         ask=_foreman_ask,
+        thinking=_foreman_thinking,
     )
 
 
@@ -760,6 +762,21 @@ async def _foreman_ask(question: str) -> str | None:
     answer = (resp.get("output") if isinstance(resp, dict) else None) or ""
     answer = answer.strip()
     return answer or None
+
+
+@asynccontextmanager
+async def _foreman_thinking(label: str):
+    """Bracket a slow LLM call with a visible `cl.Step` spinner.
+
+    Dispatcher's `_synthesize_answer` enters this around the follow-up
+    backend call so the user sees "Interpreting the output…" with a
+    live spinner instead of an awkward silent pause between the command
+    output and the prose synthesis. The step auto-closes (spinner goes
+    away) as soon as the synthesis message lands, regardless of success
+    or failure.
+    """
+    async with cl.Step(name=label, type="run") as step:
+        yield step
 
 
 # ---------- real intercept demo (P2.6) ----------

--- a/server/dispatcher.py
+++ b/server/dispatcher.py
@@ -398,6 +398,22 @@ def _parse_explicit(text: str) -> Optional[list[str]]:
 
 SayFn = Callable[[str], Awaitable[None]]
 AskFn = Callable[[str], Awaitable[Optional[str]]]
+# `thinking(label)` returns an async context manager the caller enters
+# around slow LLM calls. The UI layer shows a spinner / "thinking…"
+# indicator while open. Main.py wires this to `cl.Step(type="run")`;
+# tests pass a recording stub. Optional — if None, no indicator fires.
+ThinkingFn = Callable[[str], Any]
+
+
+class _NullAsyncContext:
+    """Degenerate async context manager used when no `thinking` is
+    provided — keeps the `async with` call site clean."""
+
+    async def __aenter__(self) -> None:
+        return None
+
+    async def __aexit__(self, exc_type: Any, exc: Any, tb: Any) -> None:
+        return None
 
 
 async def _synthesize_answer(
@@ -408,6 +424,7 @@ async def _synthesize_answer(
     rc: int,
     backend: BackendCallable,
     say: SayFn,
+    thinking: Optional[ThinkingFn] = None,
 ) -> None:
     """One extra LLM call that interprets command output in plain prose.
 
@@ -442,10 +459,18 @@ async def _synthesize_answer(
         f"Exit code: {rc}"
     )
 
+    # Show a "thinking…" spinner around the synthesis call so the gap
+    # between the code-fenced output and the prose answer doesn't feel
+    # like the agent has stalled. The context manager auto-closes on
+    # exit (success, failure, or exception) so the spinner always
+    # clears exactly once.
+    ctx_factory = thinking if thinking is not None else (lambda _label: _NullAsyncContext())
+
     try:
-        raw, in_tok, out_tok = await backend(
-            FOLLOWUP_SYSTEM_PROMPT, followup_prompt
-        )
+        async with ctx_factory("Interpreting the output…"):
+            raw, in_tok, out_tok = await backend(
+                FOLLOWUP_SYSTEM_PROMPT, followup_prompt
+            )
     except Exception as exc:  # noqa: BLE001 — fail soft, don't mask raw output
         print(
             f"[dispatcher] synthesis backend raised: {type(exc).__name__}: {exc}",
@@ -473,6 +498,7 @@ async def dispatch(
     say: SayFn,
     ask: AskFn,
     step: Optional[Any] = None,
+    thinking: Optional[ThinkingFn] = None,
 ) -> None:
     """Route `user_text` to execute / clarify / answer.
 
@@ -480,7 +506,9 @@ async def dispatch(
     prompts the admin and returns the answer (or None on timeout).
     `step` is forwarded to `intercept.execute_command` when the
     dispatcher picks "execute" — a live `cl.Step` the caller already
-    opened to stream subprocess output into.
+    opened to stream subprocess output into. `thinking(label)` returns
+    an async context manager that bookends slow LLM synthesis calls
+    so the UI can render a spinner; pass `None` to disable.
     """
     import sys
 
@@ -610,6 +638,7 @@ async def dispatch(
                     rc=rc,
                     backend=backend,
                     say=say,
+                    thinking=thinking,
                 )
             return
 

--- a/tests/test_dispatcher.py
+++ b/tests/test_dispatcher.py
@@ -438,6 +438,123 @@ async def test_dispatch_synthesis_skipped_on_empty_output() -> None:
     print("test_dispatch_synthesis_skipped_on_empty_output: OK")
 
 
+async def test_dispatch_thinking_brackets_synthesis_call() -> None:
+    """When `thinking` is provided, it must be entered BEFORE the synthesis
+    backend call and exited AFTER — so the UI spinner actually covers the
+    slow part. Empty-output and rejected paths skip synthesis entirely,
+    so `thinking` must NOT be entered in those cases either."""
+    _reset()
+
+    events: list[tuple[str, str | None]] = []
+
+    class ThinkingRecorder:
+        def __init__(self, label: str) -> None:
+            self.label = label
+
+        async def __aenter__(self):
+            events.append(("enter", self.label))
+            return self
+
+        async def __aexit__(self, exc_type, exc, tb):
+            events.append(("exit", self.label))
+            return False
+
+    def thinking_factory(label: str) -> ThinkingRecorder:
+        return ThinkingRecorder(label)
+
+    say = SayRecorder()
+    ask = AskScript([])
+
+    async def tracking_backend(system: str, user: str) -> dispatcher.BackendResult:
+        events.append(("backend", system[:30]))
+        if system.startswith("You are Foreman, the chat agent"):
+            # First call — classifier picks execute
+            return (
+                '{"type": "execute", "argv": ["echo", "tracked"], "rationale": "trace"}',
+                40,
+                20,
+            )
+        # Second call — synthesis
+        return ("I counted 'tracked' in the output.", 30, 15)
+
+    dispatcher.set_backend(tracking_backend)
+
+    await dispatcher.dispatch(
+        "trace the flow",
+        say=say,
+        ask=ask,
+        thinking=thinking_factory,
+    )
+
+    # Synthesis message landed
+    assert any("counted 'tracked'" in m for m in say.messages), say.messages
+
+    # Event order must be:
+    #   backend (classifier) → backend (synthesis) wrapped by enter/exit
+    # i.e. the thinking block brackets ONLY the synthesis call.
+    backend_events = [e for e in events if e[0] == "backend"]
+    thinking_events = [e for e in events if e[0] in ("enter", "exit")]
+
+    assert len(backend_events) == 2, backend_events
+    assert len(thinking_events) == 2, thinking_events
+    assert thinking_events[0][0] == "enter"
+    assert thinking_events[1][0] == "exit"
+    assert "Interpreting" in thinking_events[0][1] or "output" in thinking_events[0][1].lower()
+
+    # Strict ordering: classifier backend call comes first, then enter,
+    # then synthesis backend, then exit.
+    ordered_kinds = [e[0] for e in events]
+    assert ordered_kinds == ["backend", "enter", "backend", "exit"], ordered_kinds
+
+    print("test_dispatch_thinking_brackets_synthesis_call: OK")
+
+
+async def test_dispatch_thinking_not_entered_when_synthesis_skipped() -> None:
+    """No synthesis → no thinking enter/exit. Covers the reject path."""
+    _reset()
+    budgets.set_limit("edits", 0)
+
+    entered = []
+
+    class Recorder:
+        def __init__(self, label: str):
+            self.label = label
+
+        async def __aenter__(self):
+            entered.append(self.label)
+
+        async def __aexit__(self, *a):
+            return False
+
+    say = SayRecorder()
+    ask = AskScript([])
+    backend = FakeBackend(
+        [
+            (
+                '{"type": "execute", "argv": ["gh", "issue", "edit", "42", '
+                '"--add-label", "x"], "rationale": "add label"}',
+                50,
+                20,
+            )
+        ]
+    )
+    dispatcher.set_backend(backend)
+
+    try:
+        await dispatcher.dispatch(
+            "add label x to issue 42",
+            say=say,
+            ask=ask,
+            thinking=lambda label: Recorder(label),
+        )
+    finally:
+        budgets.set_limit("edits", budgets.DEFAULT_LIMITS["edits"])
+
+    # Rejected → no synthesis → thinking factory never called
+    assert entered == [], entered
+    print("test_dispatch_thinking_not_entered_when_synthesis_skipped: OK")
+
+
 async def test_dispatch_synthesis_failure_is_soft() -> None:
     """If the synthesis backend call raises, the admin still gets the raw output."""
     _reset()
@@ -595,6 +712,8 @@ async def amain() -> None:
     await test_dispatch_clarify_then_execute()
     await test_dispatch_synthesis_skipped_on_reject()
     await test_dispatch_synthesis_skipped_on_empty_output()
+    await test_dispatch_thinking_brackets_synthesis_call()
+    await test_dispatch_thinking_not_entered_when_synthesis_skipped()
     await test_dispatch_synthesis_failure_is_soft()
     await test_dispatch_explicit_shortcut_skips_backend()
     await test_dispatch_clarify_loop_bounded()


### PR DESCRIPTION
## Summary

Follow-up to KKallas/Imp#36 / PR #37. Removes the silent pause between the "Exit code" line and the synthesized answer — the gap felt like the agent had stalled because the second LLM call can take several seconds.

Adds an optional `thinking(label)` callable to `dispatch()` and `_synthesize_answer`. It's an async-context-manager factory; main.py wires it to `cl.Step(type="run")`, so the chat renders a live "Interpreting the output…" spinner while the synthesis backend call is in flight. The step auto-closes (spinner clears) as soon as the synthesis message lands, on success OR exception.

## What changed

- **`server/dispatcher.py`**:
  - New `ThinkingFn` type + `_NullAsyncContext` no-op fallback.
  - `_synthesize_answer` accepts an optional `thinking` param; wraps the backend call in `async with thinking("Interpreting the output…"):`.
  - `dispatch()` gains the same optional param and forwards it.

- **`main.py`**:
  - New `_foreman_thinking` async-context-manager function wrapping `cl.Step(name=label, type="run")`.
  - Wired into the `dispatcher.dispatch()` call alongside `say` / `ask`.
  - Added `from contextlib import asynccontextmanager` import.

- **`tests/test_dispatcher.py`**:
  - `test_dispatch_thinking_brackets_synthesis_call` — verifies strict event ordering: classifier-backend → thinking-enter → synthesis-backend → thinking-exit. No stray entries on either side.
  - `test_dispatch_thinking_not_entered_when_synthesis_skipped` — rejected actions skip synthesis, so the factory must not fire.

## Chat experience after this lands

> **You:** how many issues are currently open?
>
> **Foreman:** Running: `gh issue list --state open`
> *Listing issues to count...*
>
> **Foreman:**
> ```
> 25  OPEN  [P7.25] docs/README.md ...
> ... 13 rows ...
> ```
> Exit code: `0`
>
> **[cl.Step]** Interpreting the output…  ← spinner visible while synthesis runs
>
> **Foreman:** You have 13 open issues spanning Phase 3 through 7...

## Test plan

- [x] `.venv/bin/python tests/test_dispatcher.py` — 28/28 pass (26 + 2 new)
- [x] `.venv/bin/python tests/test_setup_agent.py` — 22/22 pass
- [x] `.venv/bin/python tests/test_budgets.py` — 18/18 pass
- [x] `.venv/bin/python tests/test_intercept.py` — 12/12 pass
- [x] `.venv/bin/python tests/test_guard.py` — 18/18 pass
- [x] `main.py` imports cleanly

## Base branch

Stacked on `p2.9b/dispatcher-synthesis` (PR #37) — should be merged AFTER #37 or rebased onto main once #37 merges. GitHub will auto-rebase in the UI once #37 lands.

🤖 Generated with [Claude Code](https://claude.com/claude-code)