### PR TITLE
[P4.12] pipeline/sync_issues.py — pull issues + project field values

### DIFF
--- a/pipeline/sync_issues.py
+++ b/pipeline/sync_issues.py
@@ -1,0 +1,329 @@
+#!/usr/bin/env python3
+"""pipeline/sync_issues.py — pull issues + project field values from GitHub.
+
+The visibility-pipeline entry point. Fetches every issue from the
+configured repo, fetches every item from the configured Projects-v2
+board (if there is one), merges them on issue number, and writes the
+result to `.imp/issues.json` for downstream pipeline scripts
+(heuristics.py, render_chart.py, scenario.py).
+
+## Inputs
+
+  - `.imp/config.json` for `repo`, `project_number`, `project_owner`.
+    Set by the Setup Agent (P3.9) and project_bootstrap (P3.10).
+
+## Output shape (.imp/issues.json)
+
+  {
+    "synced_at": "<ISO 8601 UTC timestamp>",
+    "repo": "<owner/name>",
+    "project_number": <int|null>,
+    "project_owner": "<owner|null>",
+    "issue_count": <int>,
+    "issues": [
+      {
+        "number": 42,
+        "title": "...",
+        "body": "...",
+        "labels": [{"name": "area:server", ...}],
+        "milestone": {"title": "Phase 4 ..."},
+        "assignees": [{"login": "..."}],
+        "state": "OPEN" | "CLOSED",
+        "url": "...",
+        "createdAt": "...",
+        "updatedAt": "...",
+        "fields": {              # custom Projects v2 field values, or {}
+          "duration_days": 5,    # NUMBER → number
+          "start_date": "...",   # DATE   → ISO YYYY-MM-DD
+          "confidence": "high",  # SINGLE_SELECT → option name
+          "depends_on": "..."    # TEXT
+        }
+      },
+      ...
+    ]
+  }
+
+## Pagination
+
+  `gh issue list --limit N` and `gh project item-list --limit N` ask
+  the gh CLI to paginate up to N results. We default `--limit 1000`,
+  which covers most repos. Set `--limit` higher if you have more.
+
+## Read-only
+
+  No `gh` writes are issued. The script can run on a freshly-set-up
+  repo without any guard / budget concern. It IS classified as a read
+  by `server/intercept.py` (PIPELINE_READ_SCRIPTS) — the Foreman
+  agent's `run_sync_issues` tool calls it without burning the edits
+  or tasks budget.
+"""
+
+from __future__ import annotations
+
+import argparse
+import json
+import subprocess
+import sys
+from datetime import datetime, timezone
+from pathlib import Path
+from typing import Any
+
+ROOT = Path(__file__).resolve().parent.parent
+CONFIG_FILE = ROOT / ".imp" / "config.json"
+OUTPUT_FILE = ROOT / ".imp" / "issues.json"
+
+DEFAULT_LIMIT = 1000
+
+# Fields we ask `gh issue list` to populate. Picked to match the AC
+# (number, title, body, labels, milestone, assignees, state) plus a
+# few extras (url + createdAt + updatedAt) that downstream scripts
+# need for chart rendering and stale-data detection.
+ISSUE_JSON_FIELDS = (
+    "number,title,body,labels,milestone,assignees,state,url,createdAt,updatedAt"
+)
+
+
+# ---------- gh runner (seam for tests) ----------
+
+
+def run_gh(argv: list[str]) -> tuple[int, str, str]:
+    """Run a gh command, return (returncode, stdout, stderr)."""
+    proc = subprocess.run(argv, capture_output=True, text=True)
+    return proc.returncode, proc.stdout or "", proc.stderr or ""
+
+
+# ---------- config I/O ----------
+
+
+def load_config() -> dict[str, Any]:
+    if CONFIG_FILE.exists():
+        try:
+            return json.loads(CONFIG_FILE.read_text())
+        except json.JSONDecodeError:
+            return {}
+    return {}
+
+
+# ---------- gh fetchers ----------
+
+
+def fetch_issues(repo: str, *, limit: int = DEFAULT_LIMIT, state: str = "all") -> list[dict[str, Any]]:
+    rc, stdout, stderr = run_gh(
+        [
+            "gh",
+            "issue",
+            "list",
+            "--repo",
+            repo,
+            "--state",
+            state,
+            "--limit",
+            str(limit),
+            "--json",
+            ISSUE_JSON_FIELDS,
+        ]
+    )
+    if rc != 0:
+        raise RuntimeError(
+            f"gh issue list failed (rc={rc}): {stderr.strip() or stdout.strip()}"
+        )
+    try:
+        data = json.loads(stdout or "[]")
+    except json.JSONDecodeError as exc:
+        raise RuntimeError(
+            f"gh issue list: unparseable JSON: {exc}; raw: {stdout[:300]!r}"
+        ) from exc
+    if not isinstance(data, list):
+        raise RuntimeError(
+            f"gh issue list returned non-list payload: {type(data).__name__}"
+        )
+    return data
+
+
+def fetch_project_items(
+    project_number: int, owner: str, *, limit: int = DEFAULT_LIMIT
+) -> list[dict[str, Any]]:
+    rc, stdout, stderr = run_gh(
+        [
+            "gh",
+            "project",
+            "item-list",
+            str(project_number),
+            "--owner",
+            owner,
+            "--limit",
+            str(limit),
+            "--format",
+            "json",
+        ]
+    )
+    if rc != 0:
+        raise RuntimeError(
+            f"gh project item-list failed (rc={rc}): "
+            f"{stderr.strip() or stdout.strip()}"
+        )
+    try:
+        data = json.loads(stdout or "{}")
+    except json.JSONDecodeError as exc:
+        raise RuntimeError(
+            f"gh project item-list: unparseable JSON: {exc}; "
+            f"raw: {stdout[:300]!r}"
+        ) from exc
+    items = data.get("items", []) if isinstance(data, dict) else data
+    return [it for it in items if isinstance(it, dict)]
+
+
+# ---------- merge ----------
+
+# Keys that gh project item-list emits at the item level that ARE NOT
+# custom fields — they're metadata about the item itself. Anything else
+# at the top level is treated as a custom field value.
+_ITEM_RESERVED_KEYS: frozenset[str] = frozenset(
+    {
+        "id",
+        "title",
+        "type",
+        "content",
+        "status",  # Status is a default Projects v2 field, kept under custom fields
+    }
+)
+
+
+def _normalize_field_value(raw: Any) -> Any:
+    """Reduce a `gh project item-list` field cell to a scalar.
+
+    For most field types gh inlines a primitive (number, string, ISO
+    date) directly, but defensively we also handle dict-shaped cells
+    in case a future gh version changes the format.
+    """
+    if isinstance(raw, dict):
+        for key in ("number", "date", "name", "text", "value"):
+            if key in raw:
+                return raw[key]
+        return raw  # unknown shape — pass through verbatim
+    return raw
+
+
+def merge_issues_with_fields(
+    issues: list[dict[str, Any]],
+    project_items: list[dict[str, Any]],
+) -> list[dict[str, Any]]:
+    """Attach project field values to each issue by issue number.
+
+    Mutates `issues` in place — adds a `"fields": {...}` key to every
+    issue dict. Issues not on the project board get `"fields": {}`.
+    PR items on the board are ignored.
+    """
+    fields_by_number: dict[int, dict[str, Any]] = {}
+    for item in project_items:
+        content = item.get("content") or {}
+        if content.get("type") != "Issue":
+            continue
+        num = content.get("number")
+        if not isinstance(num, int):
+            continue
+        custom: dict[str, Any] = {}
+        for key, value in item.items():
+            if key in _ITEM_RESERVED_KEYS:
+                continue
+            custom[key] = _normalize_field_value(value)
+        fields_by_number[num] = custom
+
+    for issue in issues:
+        num = issue.get("number")
+        if isinstance(num, int):
+            issue["fields"] = fields_by_number.get(num, {})
+        else:
+            issue["fields"] = {}
+
+    return issues
+
+
+# ---------- orchestration ----------
+
+
+def sync(
+    *,
+    limit: int = DEFAULT_LIMIT,
+    state: str = "all",
+) -> dict[str, Any]:
+    """Run the full sync. Returns the JSON dict that's also written to
+    `.imp/issues.json`."""
+    cfg = load_config()
+    repo = cfg.get("repo")
+    if not repo:
+        raise RuntimeError(
+            "no `repo` in .imp/config.json — run the Setup Agent first"
+        )
+
+    issues = fetch_issues(repo, limit=limit, state=state)
+
+    project_number = cfg.get("project_number")
+    project_owner = cfg.get("project_owner") or _owner_from_repo(repo)
+
+    if isinstance(project_number, int) and project_owner:
+        items = fetch_project_items(project_number, project_owner, limit=limit)
+        merge_issues_with_fields(issues, items)
+    else:
+        # No project board configured — every issue gets an empty
+        # fields dict so downstream scripts can rely on the key existing.
+        for issue in issues:
+            issue["fields"] = {}
+
+    return {
+        "synced_at": datetime.now(timezone.utc).isoformat(),
+        "repo": repo,
+        "project_number": project_number,
+        "project_owner": project_owner,
+        "issue_count": len(issues),
+        "issues": issues,
+    }
+
+
+def _owner_from_repo(repo: str) -> str | None:
+    """Extract `owner` from `owner/name` — fallback when project_owner
+    isn't set explicitly in config."""
+    if "/" in repo:
+        return repo.split("/", 1)[0]
+    return None
+
+
+def write_output(payload: dict[str, Any], path: Path = OUTPUT_FILE) -> None:
+    path.parent.mkdir(exist_ok=True)
+    path.write_text(json.dumps(payload, indent=2))
+
+
+def main() -> int:
+    parser = argparse.ArgumentParser(description=__doc__)
+    parser.add_argument(
+        "--limit",
+        type=int,
+        default=DEFAULT_LIMIT,
+        help=f"Max issues / project items to fetch (default {DEFAULT_LIMIT})",
+    )
+    parser.add_argument(
+        "--state",
+        default="all",
+        choices=["open", "closed", "all"],
+        help="Issue state filter (default: all)",
+    )
+    args = parser.parse_args()
+
+    try:
+        payload = sync(limit=args.limit, state=args.state)
+    except Exception as exc:  # noqa: BLE001 — surface to caller (Foreman)
+        print(str(exc), file=sys.stderr)
+        return 1
+
+    write_output(payload)
+    print(
+        f"Synced {payload['issue_count']} issues from {payload['repo']} "
+        f"→ {OUTPUT_FILE}",
+        file=sys.stderr,
+    )
+    print(json.dumps(payload, indent=2))
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/tests/test_sync_issues.py
+++ b/tests/test_sync_issues.py
@@ -1,0 +1,422 @@
+"""Tests for pipeline/sync_issues.py.
+
+Run directly: `.venv/bin/python tests/test_sync_issues.py`
+No pytest. Asserts → exit 0 on success, exit 1 on failure.
+
+Mocks `sync_issues.run_gh` with a scripted FakeGh — no real `gh` binary,
+no GitHub API calls.
+
+`CONFIG_FILE` and `OUTPUT_FILE` are redirected to a tempdir so the
+shared `.imp/` is never touched.
+"""
+
+from __future__ import annotations
+
+import json
+import sys
+import tempfile
+from pathlib import Path
+
+ROOT = Path(__file__).resolve().parent.parent
+sys.path.insert(0, str(ROOT / "pipeline"))
+
+import sync_issues as si  # noqa: E402
+
+_TMP_DIR = Path(tempfile.mkdtemp(prefix="imp-sync-test-"))
+si.CONFIG_FILE = _TMP_DIR / "config.json"
+si.OUTPUT_FILE = _TMP_DIR / "issues.json"
+
+
+# ---------- fake gh ----------
+
+
+class FakeGh:
+    """Argv-pattern matched scripted responses (rc, stdout, stderr).
+
+    Same shape as project_bootstrap's FakeGh — patterns are ordered
+    subsequences in argv, None matches any token.
+    """
+
+    def __init__(
+        self, responses: list[tuple[list[str], int, str, str]]
+    ) -> None:
+        self.responses = list(responses)
+        self.calls: list[list[str]] = []
+
+    def _matches(self, argv: list[str], pattern: list[str]) -> bool:
+        i = 0
+        for tok in argv:
+            if i >= len(pattern):
+                return True
+            if pattern[i] is None or pattern[i] == tok:
+                i += 1
+        return i >= len(pattern)
+
+    def __call__(self, argv: list[str]) -> tuple[int, str, str]:
+        self.calls.append(list(argv))
+        for idx, (pattern, rc, stdout, stderr) in enumerate(self.responses):
+            if self._matches(argv, pattern):
+                self.responses.pop(idx)
+                return (rc, stdout, stderr)
+        raise AssertionError(
+            f"FakeGh had no scripted response for argv={argv!r}; "
+            f"remaining patterns={[p for p, _, _, _ in self.responses]!r}"
+        )
+
+
+def _reset() -> None:
+    for path in (si.CONFIG_FILE, si.OUTPUT_FILE):
+        if path.exists():
+            path.unlink()
+
+
+def _write_config(cfg: dict) -> None:
+    si.CONFIG_FILE.parent.mkdir(exist_ok=True)
+    si.CONFIG_FILE.write_text(json.dumps(cfg, indent=2))
+
+
+# ---------- helpers / utilities ----------
+
+
+def test_normalize_field_value_passes_scalars() -> None:
+    _reset()
+    assert si._normalize_field_value(5) == 5
+    assert si._normalize_field_value("high") == "high"
+    assert si._normalize_field_value("2026-04-01") == "2026-04-01"
+    assert si._normalize_field_value(None) is None
+    print("test_normalize_field_value_passes_scalars: OK")
+
+
+def test_normalize_field_value_unwraps_dict_shapes() -> None:
+    """Defensive — handle dict cells in case gh changes the format."""
+    _reset()
+    assert si._normalize_field_value({"number": 5}) == 5
+    assert si._normalize_field_value({"date": "2026-04-01"}) == "2026-04-01"
+    assert si._normalize_field_value({"name": "high"}) == "high"
+    assert si._normalize_field_value({"text": "hi"}) == "hi"
+    # Unknown shape passes through unchanged
+    assert si._normalize_field_value({"weird": 1}) == {"weird": 1}
+    print("test_normalize_field_value_unwraps_dict_shapes: OK")
+
+
+def test_owner_from_repo() -> None:
+    _reset()
+    assert si._owner_from_repo("KKallas/Imp") == "KKallas"
+    assert si._owner_from_repo("nostrasht") is None
+    print("test_owner_from_repo: OK")
+
+
+# ---------- fetch ----------
+
+
+def test_fetch_issues_builds_argv_and_parses_json() -> None:
+    _reset()
+    payload = json.dumps(
+        [
+            {
+                "number": 42,
+                "title": "P4.11",
+                "body": "...",
+                "labels": [{"name": "area:server"}],
+                "milestone": {"title": "Phase 4"},
+                "assignees": [],
+                "state": "OPEN",
+                "url": "...",
+                "createdAt": "2026-04-11T12:30:18Z",
+                "updatedAt": "2026-04-15T06:00:00Z",
+            }
+        ]
+    )
+    fake = FakeGh([(["gh", "issue", "list"], 0, payload, "")])
+    si.run_gh = fake
+
+    issues = si.fetch_issues("KKallas/Imp", limit=500, state="open")
+    assert len(issues) == 1
+    assert issues[0]["number"] == 42
+
+    call = fake.calls[0]
+    assert "--repo" in call and "KKallas/Imp" in call
+    assert "--state" in call and "open" in call
+    assert "--limit" in call and "500" in call
+    assert "--json" in call
+    print("test_fetch_issues_builds_argv_and_parses_json: OK")
+
+
+def test_fetch_issues_surfaces_gh_error() -> None:
+    _reset()
+    fake = FakeGh(
+        [(["gh", "issue", "list"], 1, "", "HTTP 401: Bad credentials")]
+    )
+    si.run_gh = fake
+    try:
+        si.fetch_issues("KKallas/Imp")
+        assert False, "expected RuntimeError"
+    except RuntimeError as exc:
+        assert "401" in str(exc)
+    print("test_fetch_issues_surfaces_gh_error: OK")
+
+
+def test_fetch_project_items_parses_items_list() -> None:
+    _reset()
+    payload = json.dumps(
+        {
+            "items": [
+                {
+                    "id": "PVTI_1",
+                    "title": "...",
+                    "type": "Issue",
+                    "content": {"type": "Issue", "number": 42, "title": "..."},
+                    "duration_days": 5,
+                    "confidence": "high",
+                }
+            ]
+        }
+    )
+    fake = FakeGh([(["gh", "project", "item-list"], 0, payload, "")])
+    si.run_gh = fake
+    items = si.fetch_project_items(7, "KKallas", limit=200)
+    assert len(items) == 1
+    assert items[0]["duration_days"] == 5
+    call = fake.calls[0]
+    assert "7" in call and "KKallas" in call
+    assert "--limit" in call and "200" in call
+    print("test_fetch_project_items_parses_items_list: OK")
+
+
+# ---------- merge ----------
+
+
+def test_merge_attaches_fields_by_issue_number() -> None:
+    _reset()
+    issues = [
+        {"number": 42, "title": "A"},
+        {"number": 43, "title": "B"},
+    ]
+    items = [
+        {
+            "id": "PVTI_1",
+            "title": "A",
+            "type": "Issue",
+            "content": {"type": "Issue", "number": 42},
+            "duration_days": 5,
+            "confidence": "high",
+        }
+    ]
+    out = si.merge_issues_with_fields(issues, items)
+    by_num = {i["number"]: i for i in out}
+    assert by_num[42]["fields"] == {"duration_days": 5, "confidence": "high"}
+    # Issue 43 isn't on the project board
+    assert by_num[43]["fields"] == {}
+    print("test_merge_attaches_fields_by_issue_number: OK")
+
+
+def test_merge_skips_pr_items() -> None:
+    _reset()
+    issues = [{"number": 1, "title": "issue"}]
+    items = [
+        {
+            "id": "PVTI_pr",
+            "type": "PullRequest",
+            "content": {"type": "PullRequest", "number": 1},
+            "duration_days": 99,
+        },
+        {
+            "id": "PVTI_iss",
+            "type": "Issue",
+            "content": {"type": "Issue", "number": 1},
+            "duration_days": 7,
+        },
+    ]
+    out = si.merge_issues_with_fields(issues, items)
+    # Only the Issue item's fields should be attached
+    assert out[0]["fields"]["duration_days"] == 7
+    print("test_merge_skips_pr_items: OK")
+
+
+def test_merge_strips_reserved_metadata_keys() -> None:
+    """`id`, `title`, `type`, `content`, and `status` are item metadata,
+    not custom field values, and shouldn't end up in `fields`."""
+    _reset()
+    items = [
+        {
+            "id": "PVTI_x",
+            "title": "stolen",
+            "type": "Issue",
+            "status": "Todo",
+            "content": {"type": "Issue", "number": 42},
+            "duration_days": 5,
+        }
+    ]
+    issues = [{"number": 42}]
+    out = si.merge_issues_with_fields(issues, items)
+    fields = out[0]["fields"]
+    assert "id" not in fields
+    assert "title" not in fields
+    assert "type" not in fields
+    assert "content" not in fields
+    assert "status" not in fields
+    assert fields == {"duration_days": 5}
+    print("test_merge_strips_reserved_metadata_keys: OK")
+
+
+def test_merge_handles_no_project_items_for_issue() -> None:
+    _reset()
+    issues = [{"number": 1}]
+    out = si.merge_issues_with_fields(issues, [])
+    assert out[0]["fields"] == {}
+    print("test_merge_handles_no_project_items_for_issue: OK")
+
+
+# ---------- orchestration: sync() ----------
+
+
+def test_sync_full_flow_with_project() -> None:
+    _reset()
+    _write_config(
+        {
+            "repo": "KKallas/Imp",
+            "project_number": 7,
+            "project_owner": "KKallas",
+        }
+    )
+    issues_payload = json.dumps(
+        [{"number": 42, "title": "A", "state": "OPEN", "labels": []}]
+    )
+    items_payload = json.dumps(
+        {
+            "items": [
+                {
+                    "id": "PVTI_1",
+                    "type": "Issue",
+                    "content": {"type": "Issue", "number": 42},
+                    "duration_days": 3,
+                }
+            ]
+        }
+    )
+    fake = FakeGh(
+        [
+            (["gh", "issue", "list"], 0, issues_payload, ""),
+            (["gh", "project", "item-list"], 0, items_payload, ""),
+        ]
+    )
+    si.run_gh = fake
+
+    payload = si.sync()
+
+    assert payload["repo"] == "KKallas/Imp"
+    assert payload["project_number"] == 7
+    assert payload["project_owner"] == "KKallas"
+    assert payload["issue_count"] == 1
+    assert payload["issues"][0]["fields"]["duration_days"] == 3
+    # ISO timestamp present
+    assert "T" in payload["synced_at"]
+    print("test_sync_full_flow_with_project: OK")
+
+
+def test_sync_skips_project_when_not_configured() -> None:
+    _reset()
+    _write_config({"repo": "KKallas/Imp"})  # no project_number
+    issues_payload = json.dumps(
+        [{"number": 1, "title": "A", "state": "OPEN", "labels": []}]
+    )
+    fake = FakeGh([(["gh", "issue", "list"], 0, issues_payload, "")])
+    si.run_gh = fake
+
+    payload = si.sync()
+
+    assert payload["project_number"] is None
+    assert payload["issues"][0]["fields"] == {}
+    # No project item-list call was made
+    assert not any("item-list" in c for c in fake.calls)
+    print("test_sync_skips_project_when_not_configured: OK")
+
+
+def test_sync_falls_back_to_owner_from_repo() -> None:
+    """If project_owner isn't set explicitly but project_number is,
+    derive owner from `repo`."""
+    _reset()
+    _write_config({"repo": "KKallas/Imp", "project_number": 7})  # no owner
+    issues_payload = json.dumps([])
+    items_payload = json.dumps({"items": []})
+    fake = FakeGh(
+        [
+            (["gh", "issue", "list"], 0, issues_payload, ""),
+            (["gh", "project", "item-list"], 0, items_payload, ""),
+        ]
+    )
+    si.run_gh = fake
+    payload = si.sync()
+    assert payload["project_owner"] == "KKallas"
+    # Verify the item-list call used the derived owner
+    item_call = next(c for c in fake.calls if "item-list" in c)
+    assert "KKallas" in item_call
+    print("test_sync_falls_back_to_owner_from_repo: OK")
+
+
+def test_sync_errors_when_no_repo_in_config() -> None:
+    _reset()
+    _write_config({})  # empty config
+    fake = FakeGh([])
+    si.run_gh = fake
+    try:
+        si.sync()
+        assert False, "expected RuntimeError"
+    except RuntimeError as exc:
+        assert "repo" in str(exc).lower()
+    print("test_sync_errors_when_no_repo_in_config: OK")
+
+
+def test_write_output_creates_imp_dir_and_writes_json() -> None:
+    _reset()
+    payload = {
+        "synced_at": "2026-04-15T06:30:00+00:00",
+        "repo": "KKallas/Imp",
+        "issue_count": 0,
+        "issues": [],
+    }
+    si.write_output(payload, path=si.OUTPUT_FILE)
+    assert si.OUTPUT_FILE.exists()
+    on_disk = json.loads(si.OUTPUT_FILE.read_text())
+    assert on_disk == payload
+    print("test_write_output_creates_imp_dir_and_writes_json: OK")
+
+
+# ---------- runner ----------
+
+
+def main() -> None:
+    tests = [
+        test_normalize_field_value_passes_scalars,
+        test_normalize_field_value_unwraps_dict_shapes,
+        test_owner_from_repo,
+        test_fetch_issues_builds_argv_and_parses_json,
+        test_fetch_issues_surfaces_gh_error,
+        test_fetch_project_items_parses_items_list,
+        test_merge_attaches_fields_by_issue_number,
+        test_merge_skips_pr_items,
+        test_merge_strips_reserved_metadata_keys,
+        test_merge_handles_no_project_items_for_issue,
+        test_sync_full_flow_with_project,
+        test_sync_skips_project_when_not_configured,
+        test_sync_falls_back_to_owner_from_repo,
+        test_sync_errors_when_no_repo_in_config,
+        test_write_output_creates_imp_dir_and_writes_json,
+    ]
+    for t in tests:
+        t()
+    print(f"\nAll {len(tests)} sync_issues tests passed.")
+
+
+if __name__ == "__main__":
+    try:
+        main()
+    except AssertionError as e:
+        print(f"\nFAIL: {e}")
+        sys.exit(1)
+    except Exception as e:
+        import traceback
+
+        print(f"\nERROR: {type(e).__name__}: {e}")
+        traceback.print_exc()
+        sys.exit(1)


### PR DESCRIPTION
## Summary

Closes KKallas/Imp#12. Adds the visibility-pipeline entry point: fetches every issue from the configured repo, fetches every Projects-v2 board item, merges them on issue number, and writes `.imp/issues.json`. Foreman's `run_sync_issues` tool (already wired in P4.11) now actually does something.

## Output shape (`.imp/issues.json`)

```json
{
  "synced_at": "2026-04-15T06:30:00+00:00",
  "repo": "KKallas/Imp",
  "project_number": 7,
  "project_owner": "KKallas",
  "issue_count": 13,
  "issues": [
    {
      "number": 11,
      "title": "[P4.11] server/foreman_agent.py ...",
      "body": "**Scope** ...",
      "labels": [{"name": "area:server"}, {"name": "imp:baseline"}],
      "milestone": {"title": "Phase 4 — Foreman & visibility tools"},
      "assignees": [],
      "state": "CLOSED",
      "url": "https://github.com/...",
      "createdAt": "2026-04-11T12:30:18Z",
      "updatedAt": "2026-04-15T06:00:00Z",
      "fields": {
        "duration_days": 5,
        "start_date": "2026-04-11",
        "end_date": "2026-04-15",
        "confidence": "high",
        "source": "github",
        "assignee_verified": "no",
        "depends_on": "#10, #9"
      }
    }
  ]
}
```

`fields` is always present — `{}` when the issue isn't on the project board or no `project_number` is configured. Downstream scripts (`heuristics.py`, `render_chart.py`, `scenario.py`) can rely on the key always existing.

## Acceptance criteria (from KKallas/Imp#12)

- [x] Output JSON contains: issue number, title, body, labels, milestone, assignees, state, all custom field values
- [x] Handles paginated repos (>100 issues) — `--limit` defaults to 1000; gh CLI auto-paginates internally
- [x] Records the sync timestamp so heuristics can detect stale data — `synced_at` ISO 8601 UTC

## Implementation notes

- **Read-only**: no `gh` writes are issued. The script is in `intercept.py`'s `PIPELINE_READ_SCRIPTS` list, so the Foreman agent's `run_sync_issues` tool calls it without burning the edits or tasks budget.
- **Defensive field normalization**: `_normalize_field_value` handles both gh's current scalar-inline format AND a dict-shaped fallback (`{"number": 5}`, `{"date": "..."}`, etc.) in case a future gh version changes the wire format.
- **Reserved-key filter**: `id`, `title`, `type`, `content`, and `status` are item metadata, not custom fields — stripped from the `fields` dict.
- **PR skipping**: PR items on the project board are ignored; this script is issues-only.
- **Owner fallback**: if `project_owner` isn't explicitly set in `.imp/config.json`, derive it from the `owner/name` portion of `repo`.

## Test plan

- [x] `.venv/bin/python tests/test_sync_issues.py` — 15/15 pass (FakeGh; no real gh binary)
- [x] `.venv/bin/python tests/test_foreman_agent.py` — 24/24 pass
- [x] `.venv/bin/python tests/test_dispatcher.py` — 26/26 pass
- [x] `.venv/bin/python tests/test_setup_agent.py` — 24/24 pass
- [x] `.venv/bin/python tests/test_project_bootstrap.py` — 15/15 pass
- [x] `.venv/bin/python tests/test_budgets.py` — 18/18 pass
- [x] `.venv/bin/python tests/test_intercept.py` — 12/12 pass
- [x] `.venv/bin/python tests/test_guard.py` — 18/18 pass
- [x] Manual: ask Foreman "sync the issues" — should call `run_sync_issues`, write `.imp/issues.json`, and the synthesized reply will mention how many were synced

🤖 Generated with [Claude Code](https://claude.com/claude-code)