### PR TITLE
[P4.13] pipeline/heuristics.py — infer durations, dependencies, delays

### DIFF
--- a/pipeline/heuristics.py
+++ b/pipeline/heuristics.py
@@ -1,0 +1,352 @@
+#!/usr/bin/env python3
+"""pipeline/heuristics.py — infer durations, dependencies, delays.
+
+Reads `.imp/issues.json` (from `sync_issues.py`), enriches each issue
+with inferred fields, and writes `.imp/enriched.json` for downstream
+chart rendering and scenario analysis.
+
+## What gets enriched
+
+Each field in `issue.fields` is upgraded from a flat scalar to a dict
+that carries its provenance:
+
+  {
+    "value": <whatever>,
+    "source": "github" | "heuristic" | "llm",
+    "confidence": "high" | "medium" | "low"
+  }
+
+Fields the sync already populated from gh keep `source: "github"` with
+high confidence. Empty fields get heuristic defaults (low / medium
+confidence) so downstream scripts always have a value to render.
+
+Two new top-level keys per issue:
+
+  - `depends_on_parsed` — `[12, 15]` or `[]`. Always present.
+    Unparseable tokens go into `depends_on_unparseable` and are logged
+    to stderr. Per v0.1.md, parse failures are soft — the issue is
+    treated as having no known dependencies for that run, not aborted.
+  - `delay` — only present when the issue is detected as delayed.
+    Comparing current `end_date` against today + the `imp:baseline`
+    label state (per the AC).
+
+A top-level `dependency_edges` array on the enriched payload makes the
+graph easy for `render_chart.py` to consume directly.
+
+## Stale-data guard
+
+The sync timestamp from `.imp/issues.json` is propagated unchanged to
+`.imp/enriched.json` plus a fresh `enriched_at` timestamp, so callers
+can detect stale enrichment vs. stale sync independently.
+
+## Read-only
+
+No GitHub side effects. Classified as a read by `server/intercept.py`
+(see PIPELINE_READ_SCRIPTS) — Foreman's `run_heuristics` tool runs it
+without burning the edits or tasks budget.
+"""
+
+from __future__ import annotations
+
+import argparse
+import json
+import re
+import sys
+from datetime import date, datetime, timezone
+from pathlib import Path
+from typing import Any
+
+ROOT = Path(__file__).resolve().parent.parent
+INPUT_FILE = ROOT / ".imp" / "issues.json"
+OUTPUT_FILE = ROOT / ".imp" / "enriched.json"
+
+# Default duration in days when nothing else informs us.
+DEFAULT_DURATION_DAYS = 3
+
+# Coarse per-label hints — not authoritative, just better than the
+# global default. Tuned from the existing P-numbering convention in
+# this repo's issues; refine over time.
+DURATION_HINT_BY_LABEL: dict[str, int] = {
+    "area:server": 3,
+    "area:pipeline": 2,
+    "area:ui": 2,
+    "imp:baseline": 5,
+}
+
+
+# ---------- depends_on parsing ----------
+
+# Per v0.1.md: "split on commas, strip `#`, ignore anything that isn't
+# an integer". Extra whitespace + leading `#` is fine; everything else
+# is unparseable and gets logged.
+_INT_TOKEN_RE = re.compile(r"^#?(\d+)$")
+
+
+def parse_depends_on(text: str) -> tuple[list[int], list[str]]:
+    """Parse a depends_on text field, return (parsed_issue_numbers, unparseable_tokens).
+
+    Always succeeds — no exceptions. Unparseable tokens come back in
+    the second tuple slot so the caller can log/surface them without
+    aborting the enrichment run.
+    """
+    if not text or not isinstance(text, str):
+        return ([], [])
+    parsed: list[int] = []
+    bad: list[str] = []
+    for raw in re.split(r"[,\s]+", text.strip()):
+        if not raw:
+            continue
+        m = _INT_TOKEN_RE.match(raw)
+        if m:
+            parsed.append(int(m.group(1)))
+        else:
+            bad.append(raw)
+    return (parsed, bad)
+
+
+# ---------- duration inference ----------
+
+
+def _labels_of(issue: dict[str, Any]) -> list[str]:
+    out: list[str] = []
+    for label in issue.get("labels") or []:
+        if isinstance(label, dict):
+            name = label.get("name")
+            if isinstance(name, str):
+                out.append(name)
+        elif isinstance(label, str):
+            out.append(label)
+    return out
+
+
+def infer_duration(issue: dict[str, Any]) -> tuple[int, str, str]:
+    """Return (days, source, confidence) for an issue's duration.
+
+    If the GitHub project field already has it, we use that with
+    `source: github / confidence: high` — there's no inference.
+    Otherwise we take the **largest** hint across matching labels and
+    fall back to the global default. Largest-wins is intentional: for a
+    PM tool, it's safer to overestimate than to underestimate, and it
+    decouples the result from GitHub's label display order.
+    """
+    fields = issue.get("fields") or {}
+    raw = fields.get("duration_days")
+    if isinstance(raw, (int, float)) and raw > 0:
+        return (int(raw), "github", "high")
+
+    hints = [
+        DURATION_HINT_BY_LABEL[label]
+        for label in _labels_of(issue)
+        if label in DURATION_HINT_BY_LABEL
+    ]
+    if hints:
+        return (max(hints), "heuristic", "medium")
+
+    return (DEFAULT_DURATION_DAYS, "heuristic", "low")
+
+
+# ---------- delay detection ----------
+
+
+def detect_delay(
+    issue: dict[str, Any], today: date | None = None
+) -> dict[str, Any] | None:
+    """Return a delay record if the issue is overdue per its baseline.
+
+    Per the AC: comparing current `end_date` to the `imp:baseline` label
+    state. We interpret that as: an issue with the `imp:baseline` label
+    that's still OPEN past its `end_date` is delayed. Issues without
+    the label (newly added, scope creep, etc.) aren't subject to this
+    check.
+
+    Closed issues, even if past their date, aren't flagged — they shipped.
+    """
+    today = today or date.today()
+    state = str(issue.get("state") or "").upper()
+    if state != "OPEN":
+        return None
+
+    if "imp:baseline" not in _labels_of(issue):
+        return None
+
+    fields = issue.get("fields") or {}
+    end_date_str = fields.get("end_date")
+    if not isinstance(end_date_str, str):
+        return None
+
+    try:
+        end = date.fromisoformat(end_date_str)
+    except ValueError:
+        return None  # malformed — soft skip
+
+    if end >= today:
+        return None  # not yet due
+
+    return {
+        "is_delayed": True,
+        "days_overdue": (today - end).days,
+        "baseline_end_date": end_date_str,
+        "reason": (
+            f"end_date {end_date_str} passed; issue still OPEN "
+            f"(baseline label present)"
+        ),
+        "source": "heuristic",
+        "confidence": "high",
+    }
+
+
+# ---------- enrichment ----------
+
+
+def _provenance_existing(value: Any) -> dict[str, Any]:
+    """Wrap a sync-supplied value in the standard provenance envelope."""
+    return {"value": value, "source": "github", "confidence": "high"}
+
+
+def enrich_issue(
+    issue: dict[str, Any], today: date | None = None
+) -> dict[str, Any]:
+    """Return a new dict — does NOT mutate `issue`.
+
+    `today` is overridable for testing the delay branch deterministically.
+    """
+    raw_fields = issue.get("fields") or {}
+    enriched_fields: dict[str, Any] = {}
+
+    # 1. Wrap every existing concrete field in provenance envelopes.
+    for key, value in raw_fields.items():
+        if value is None:
+            continue
+        enriched_fields[key] = _provenance_existing(value)
+
+    # 2. Duration: prefer github value (already wrapped above); else heuristic.
+    if "duration_days" not in enriched_fields:
+        days, source, confidence = infer_duration(issue)
+        enriched_fields["duration_days"] = {
+            "value": days,
+            "source": source,
+            "confidence": confidence,
+        }
+
+    # 3. depends_on parsing — always run, even if value is empty/null.
+    raw_depends = raw_fields.get("depends_on")
+    parsed, bad = parse_depends_on(str(raw_depends or ""))
+    if bad:
+        # Log to stderr but DON'T abort the run.
+        print(
+            f"[heuristics] issue #{issue.get('number')}: unparseable "
+            f"depends_on tokens: {bad!r}",
+            file=sys.stderr,
+        )
+    # Replace the raw text envelope with a structured value.
+    enriched_fields["depends_on"] = {
+        "value": parsed,
+        "raw": raw_depends,
+        "unparseable": bad,
+        "source": "heuristic",
+        "confidence": "high" if not bad else "medium",
+    }
+
+    out = dict(issue)
+    out["fields"] = enriched_fields
+    out["depends_on_parsed"] = parsed
+    if bad:
+        out["depends_on_unparseable"] = bad
+
+    delay = detect_delay(issue, today=today)
+    if delay is not None:
+        out["delay"] = delay
+
+    return out
+
+
+def build_dependency_edges(
+    enriched_issues: list[dict[str, Any]],
+) -> list[dict[str, Any]]:
+    """Emit `[{from: 12, to: 5}, ...]` for downstream graph rendering.
+
+    `from -> to` reads as "issue 12 depends on issue 5"; render_chart
+    treats `to` as the predecessor. Edges to issues that aren't in the
+    sync's issue set are still emitted (the chart can show them as
+    external).
+    """
+    edges: list[dict[str, Any]] = []
+    for issue in enriched_issues:
+        src = issue.get("number")
+        if not isinstance(src, int):
+            continue
+        for dep in issue.get("depends_on_parsed") or []:
+            if isinstance(dep, int) and dep != src:
+                edges.append({"from": src, "to": dep})
+    return edges
+
+
+def enrich(
+    payload: dict[str, Any], today: date | None = None
+) -> dict[str, Any]:
+    """Take a sync_issues output dict, return the enriched dict."""
+    issues = payload.get("issues") or []
+    enriched_issues = [enrich_issue(it, today=today) for it in issues]
+    return {
+        **payload,
+        "enriched_at": datetime.now(timezone.utc).isoformat(),
+        "issues": enriched_issues,
+        "dependency_edges": build_dependency_edges(enriched_issues),
+        "delayed_count": sum(1 for it in enriched_issues if it.get("delay")),
+    }
+
+
+# ---------- I/O ----------
+
+
+def load_input(path: Path = INPUT_FILE) -> dict[str, Any]:
+    if not path.exists():
+        raise FileNotFoundError(
+            f"{path} not found — run `pipeline/sync_issues.py` first"
+        )
+    return json.loads(path.read_text())
+
+
+def write_output(payload: dict[str, Any], path: Path = OUTPUT_FILE) -> None:
+    path.parent.mkdir(exist_ok=True)
+    path.write_text(json.dumps(payload, indent=2))
+
+
+def main() -> int:
+    parser = argparse.ArgumentParser(description=__doc__)
+    parser.add_argument(
+        "--input",
+        type=Path,
+        default=INPUT_FILE,
+        help=f"Path to sync_issues output (default {INPUT_FILE})",
+    )
+    parser.add_argument(
+        "--output",
+        type=Path,
+        default=OUTPUT_FILE,
+        help=f"Path to enriched output (default {OUTPUT_FILE})",
+    )
+    args = parser.parse_args()
+
+    try:
+        payload = load_input(args.input)
+    except Exception as exc:  # noqa: BLE001 — surface to Foreman
+        print(str(exc), file=sys.stderr)
+        return 1
+
+    enriched = enrich(payload)
+    write_output(enriched, args.output)
+
+    print(
+        f"Enriched {len(enriched['issues'])} issues "
+        f"({enriched['delayed_count']} delayed, "
+        f"{len(enriched['dependency_edges'])} dependency edges) "
+        f"→ {args.output}",
+        file=sys.stderr,
+    )
+    print(json.dumps(enriched, indent=2))
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/tests/fixtures/sample_issues.json
+++ b/tests/fixtures/sample_issues.json
@@ -1,0 +1,107 @@
+{
+  "synced_at": "2026-04-15T06:30:00+00:00",
+  "repo": "KKallas/Imp",
+  "project_number": 7,
+  "project_owner": "KKallas",
+  "issue_count": 6,
+  "issues": [
+    {
+      "number": 11,
+      "title": "[P4.11] server/foreman_agent.py — worker definition",
+      "body": "Foreman worker agent ...",
+      "labels": [
+        {"name": "area:server"},
+        {"name": "imp:baseline"}
+      ],
+      "milestone": {"title": "Phase 4 — Foreman & visibility tools"},
+      "assignees": [],
+      "state": "CLOSED",
+      "url": "https://github.com/KKallas/Imp/issues/11",
+      "createdAt": "2026-04-11T12:30:18Z",
+      "updatedAt": "2026-04-15T06:00:00Z",
+      "fields": {
+        "duration_days": 4,
+        "start_date": "2026-04-11",
+        "end_date": "2026-04-15",
+        "confidence": "high",
+        "source": "github",
+        "assignee_verified": "no",
+        "depends_on": "#10, #9"
+      }
+    },
+    {
+      "number": 12,
+      "title": "[P4.12] sync_issues.py",
+      "body": "...",
+      "labels": [{"name": "area:pipeline"}, {"name": "imp:baseline"}],
+      "milestone": null,
+      "assignees": [],
+      "state": "OPEN",
+      "url": "https://github.com/KKallas/Imp/issues/12",
+      "createdAt": "2026-04-12T08:00:00Z",
+      "updatedAt": "2026-04-12T08:00:00Z",
+      "fields": {
+        "end_date": "2026-04-13",
+        "depends_on": "#11"
+      }
+    },
+    {
+      "number": 13,
+      "title": "[P4.13] heuristics.py — fresh, no fields",
+      "body": "...",
+      "labels": [{"name": "area:pipeline"}],
+      "milestone": null,
+      "assignees": [],
+      "state": "OPEN",
+      "url": "https://github.com/KKallas/Imp/issues/13",
+      "createdAt": "2026-04-13T08:00:00Z",
+      "updatedAt": "2026-04-13T08:00:00Z",
+      "fields": {}
+    },
+    {
+      "number": 14,
+      "title": "Issue with messy depends_on",
+      "body": "...",
+      "labels": [{"name": "imp:baseline"}],
+      "milestone": null,
+      "assignees": [],
+      "state": "OPEN",
+      "url": "https://github.com/KKallas/Imp/issues/14",
+      "createdAt": "2026-04-14T08:00:00Z",
+      "updatedAt": "2026-04-14T08:00:00Z",
+      "fields": {
+        "depends_on": "#12, see also TBD-43, #garbage, 99"
+      }
+    },
+    {
+      "number": 15,
+      "title": "Closed past its end_date — NOT delayed",
+      "body": "...",
+      "labels": [{"name": "imp:baseline"}],
+      "milestone": null,
+      "assignees": [],
+      "state": "CLOSED",
+      "url": "https://github.com/KKallas/Imp/issues/15",
+      "createdAt": "2026-04-01T08:00:00Z",
+      "updatedAt": "2026-04-10T08:00:00Z",
+      "fields": {
+        "end_date": "2026-04-05"
+      }
+    },
+    {
+      "number": 16,
+      "title": "Open past end_date but no imp:baseline label — NOT delayed",
+      "body": "...",
+      "labels": [{"name": "area:pipeline"}],
+      "milestone": null,
+      "assignees": [],
+      "state": "OPEN",
+      "url": "https://github.com/KKallas/Imp/issues/16",
+      "createdAt": "2026-04-01T08:00:00Z",
+      "updatedAt": "2026-04-10T08:00:00Z",
+      "fields": {
+        "end_date": "2026-04-05"
+      }
+    }
+  ]
+}

--- a/tests/test_heuristics.py
+++ b/tests/test_heuristics.py
@@ -1,0 +1,367 @@
+"""Tests for pipeline/heuristics.py.
+
+Run directly: `.venv/bin/python tests/test_heuristics.py`
+No pytest. Asserts → exit 0 on success, exit 1 on failure.
+
+Targets each helper in isolation plus the full `enrich()` flow against
+the canonical fixture at `tests/fixtures/sample_issues.json`. No
+network / no gh dependency — heuristics is pure data transform.
+"""
+
+from __future__ import annotations
+
+import json
+import sys
+from datetime import date
+from pathlib import Path
+
+ROOT = Path(__file__).resolve().parent.parent
+sys.path.insert(0, str(ROOT / "pipeline"))
+
+import heuristics as h  # noqa: E402
+
+FIXTURE = Path(__file__).parent / "fixtures" / "sample_issues.json"
+
+# Pin "today" so the delay tests are deterministic. Fixture issue #12
+# has end_date=2026-04-13 and is OPEN with imp:baseline → delayed by
+# 2 days against this anchor.
+TODAY = date(2026, 4, 15)
+
+
+# ---------- parse_depends_on ----------
+
+
+def test_parse_depends_on_basic_hash_csv() -> None:
+    parsed, bad = h.parse_depends_on("#12, #15")
+    assert parsed == [12, 15]
+    assert bad == []
+    print("test_parse_depends_on_basic_hash_csv: OK")
+
+
+def test_parse_depends_on_strips_hash_and_whitespace() -> None:
+    parsed, bad = h.parse_depends_on("  12 ,  #99  ,  3 ")
+    assert parsed == [12, 99, 3]
+    assert bad == []
+    print("test_parse_depends_on_strips_hash_and_whitespace: OK")
+
+
+def test_parse_depends_on_empty_or_none() -> None:
+    assert h.parse_depends_on("") == ([], [])
+    assert h.parse_depends_on("   ") == ([], [])
+    # Defensive against non-string inputs the caller might forward
+    assert h.parse_depends_on(None) == ([], [])  # type: ignore[arg-type]
+    print("test_parse_depends_on_empty_or_none: OK")
+
+
+def test_parse_depends_on_collects_unparseable_without_aborting() -> None:
+    """Per AC: unparseable values are logged but do NOT abort."""
+    parsed, bad = h.parse_depends_on("#12, garbage, TBD-43, 99, #not-a-num, 5")
+    assert parsed == [12, 99, 5]
+    assert sorted(bad) == sorted(["garbage", "TBD-43", "#not-a-num"])
+    print("test_parse_depends_on_collects_unparseable_without_aborting: OK")
+
+
+# ---------- infer_duration ----------
+
+
+def test_infer_duration_uses_github_value_when_present() -> None:
+    issue = {"fields": {"duration_days": 7}, "labels": []}
+    days, source, conf = h.infer_duration(issue)
+    assert days == 7
+    assert source == "github"
+    assert conf == "high"
+    print("test_infer_duration_uses_github_value_when_present: OK")
+
+
+def test_infer_duration_uses_label_hint_when_field_missing() -> None:
+    issue = {"fields": {}, "labels": [{"name": "area:server"}]}
+    days, source, conf = h.infer_duration(issue)
+    assert days == h.DURATION_HINT_BY_LABEL["area:server"]
+    assert source == "heuristic"
+    assert conf == "medium"
+    print("test_infer_duration_uses_label_hint_when_field_missing: OK")
+
+
+def test_infer_duration_falls_back_to_default() -> None:
+    issue = {"fields": {}, "labels": [{"name": "unknown"}]}
+    days, source, conf = h.infer_duration(issue)
+    assert days == h.DEFAULT_DURATION_DAYS
+    assert source == "heuristic"
+    assert conf == "low"
+    print("test_infer_duration_falls_back_to_default: OK")
+
+
+def test_infer_duration_handles_zero_or_negative_as_missing() -> None:
+    """A 0 or negative duration_days shouldn't be trusted."""
+    issue = {"fields": {"duration_days": 0}, "labels": [{"name": "area:server"}]}
+    days, source, _ = h.infer_duration(issue)
+    assert source == "heuristic"
+    assert days == h.DURATION_HINT_BY_LABEL["area:server"]
+    print("test_infer_duration_handles_zero_or_negative_as_missing: OK")
+
+
+# ---------- detect_delay ----------
+
+
+def test_detect_delay_returns_record_for_overdue_open_baseline_issue() -> None:
+    issue = {
+        "state": "OPEN",
+        "labels": [{"name": "imp:baseline"}],
+        "fields": {"end_date": "2026-04-13"},
+    }
+    delay = h.detect_delay(issue, today=TODAY)
+    assert delay is not None
+    assert delay["is_delayed"] is True
+    assert delay["days_overdue"] == 2
+    assert delay["source"] == "heuristic"
+    assert "passed" in delay["reason"].lower()
+    print("test_detect_delay_returns_record_for_overdue_open_baseline_issue: OK")
+
+
+def test_detect_delay_skips_closed_issue_even_if_overdue() -> None:
+    issue = {
+        "state": "CLOSED",
+        "labels": [{"name": "imp:baseline"}],
+        "fields": {"end_date": "2026-04-05"},
+    }
+    assert h.detect_delay(issue, today=TODAY) is None
+    print("test_detect_delay_skips_closed_issue_even_if_overdue: OK")
+
+
+def test_detect_delay_skips_issue_without_baseline_label() -> None:
+    issue = {
+        "state": "OPEN",
+        "labels": [{"name": "area:pipeline"}],
+        "fields": {"end_date": "2026-04-05"},
+    }
+    assert h.detect_delay(issue, today=TODAY) is None
+    print("test_detect_delay_skips_issue_without_baseline_label: OK")
+
+
+def test_detect_delay_skips_issue_without_end_date() -> None:
+    issue = {
+        "state": "OPEN",
+        "labels": [{"name": "imp:baseline"}],
+        "fields": {},
+    }
+    assert h.detect_delay(issue, today=TODAY) is None
+    print("test_detect_delay_skips_issue_without_end_date: OK")
+
+
+def test_detect_delay_skips_when_end_date_in_future() -> None:
+    issue = {
+        "state": "OPEN",
+        "labels": [{"name": "imp:baseline"}],
+        "fields": {"end_date": "2026-12-01"},
+    }
+    assert h.detect_delay(issue, today=TODAY) is None
+    print("test_detect_delay_skips_when_end_date_in_future: OK")
+
+
+def test_detect_delay_soft_skip_on_malformed_date() -> None:
+    issue = {
+        "state": "OPEN",
+        "labels": [{"name": "imp:baseline"}],
+        "fields": {"end_date": "not-a-date"},
+    }
+    assert h.detect_delay(issue, today=TODAY) is None
+    print("test_detect_delay_soft_skip_on_malformed_date: OK")
+
+
+# ---------- enrich (single issue + full payload) ----------
+
+
+def test_enrich_issue_wraps_existing_fields_with_provenance() -> None:
+    issue = {
+        "number": 11,
+        "labels": [{"name": "area:server"}],
+        "state": "CLOSED",
+        "fields": {"duration_days": 4, "confidence": "high"},
+    }
+    out = h.enrich_issue(issue, today=TODAY)
+    fields = out["fields"]
+    # Existing values get the github envelope
+    assert fields["duration_days"]["source"] == "github"
+    assert fields["duration_days"]["value"] == 4
+    assert fields["confidence"]["source"] == "github"
+    assert fields["confidence"]["value"] == "high"
+    print("test_enrich_issue_wraps_existing_fields_with_provenance: OK")
+
+
+def test_enrich_issue_attaches_depends_on_parsed_array() -> None:
+    issue = {
+        "number": 14,
+        "labels": [{"name": "imp:baseline"}],
+        "state": "OPEN",
+        "fields": {"depends_on": "#12, garbage, #99"},
+    }
+    out = h.enrich_issue(issue, today=TODAY)
+    assert out["depends_on_parsed"] == [12, 99]
+    assert out["depends_on_unparseable"] == ["garbage"]
+    deps_field = out["fields"]["depends_on"]
+    assert deps_field["value"] == [12, 99]
+    assert deps_field["raw"] == "#12, garbage, #99"
+    assert deps_field["unparseable"] == ["garbage"]
+    # Confidence drops to medium when there were parse failures
+    assert deps_field["confidence"] == "medium"
+    print("test_enrich_issue_attaches_depends_on_parsed_array: OK")
+
+
+def test_enrich_issue_attaches_delay_record_when_overdue() -> None:
+    issue = {
+        "number": 12,
+        "state": "OPEN",
+        "labels": [{"name": "imp:baseline"}],
+        "fields": {"end_date": "2026-04-13"},
+    }
+    out = h.enrich_issue(issue, today=TODAY)
+    assert "delay" in out
+    assert out["delay"]["days_overdue"] == 2
+    print("test_enrich_issue_attaches_delay_record_when_overdue: OK")
+
+
+def test_enrich_issue_no_delay_key_when_not_delayed() -> None:
+    issue = {
+        "number": 11,
+        "state": "CLOSED",
+        "labels": [{"name": "imp:baseline"}],
+        "fields": {"end_date": "2026-04-15"},
+    }
+    out = h.enrich_issue(issue, today=TODAY)
+    assert "delay" not in out
+    print("test_enrich_issue_no_delay_key_when_not_delayed: OK")
+
+
+def test_enrich_issue_does_not_mutate_input() -> None:
+    issue = {
+        "number": 1,
+        "state": "OPEN",
+        "labels": [],
+        "fields": {"duration_days": 5},
+    }
+    snapshot = json.dumps(issue, sort_keys=True)
+    h.enrich_issue(issue, today=TODAY)
+    assert json.dumps(issue, sort_keys=True) == snapshot
+    print("test_enrich_issue_does_not_mutate_input: OK")
+
+
+def test_enrich_full_payload_against_fixture() -> None:
+    """End-to-end: fixture in → enriched payload out, with the right
+    counts and shapes."""
+    payload = json.loads(FIXTURE.read_text())
+    enriched = h.enrich(payload, today=TODAY)
+
+    # Top-level shape
+    assert enriched["repo"] == "KKallas/Imp"
+    assert enriched["issue_count"] == payload["issue_count"]
+    assert "enriched_at" in enriched
+    assert "T" in enriched["enriched_at"]
+    # Sync timestamp preserved unchanged
+    assert enriched["synced_at"] == payload["synced_at"]
+
+    by_num = {it["number"]: it for it in enriched["issues"]}
+
+    # #11: closed, has all fields → no delay, github source on each field
+    assert "delay" not in by_num[11]
+    assert by_num[11]["fields"]["duration_days"]["source"] == "github"
+    assert by_num[11]["depends_on_parsed"] == [10, 9]
+
+    # #12: OPEN, imp:baseline, end_date 2026-04-13 → delayed by 2 days
+    assert "delay" in by_num[12]
+    assert by_num[12]["delay"]["days_overdue"] == 2
+    # No github duration → heuristic from "imp:baseline" label hint
+    dur12 = by_num[12]["fields"]["duration_days"]
+    assert dur12["source"] == "heuristic"
+    assert dur12["value"] == h.DURATION_HINT_BY_LABEL["imp:baseline"]
+
+    # #13: empty fields, "area:pipeline" label → heuristic medium
+    dur13 = by_num[13]["fields"]["duration_days"]
+    assert dur13["source"] == "heuristic"
+    assert dur13["value"] == h.DURATION_HINT_BY_LABEL["area:pipeline"]
+    assert dur13["confidence"] == "medium"
+    # Depends_on was not present → empty parsed list, no unparseable
+    assert by_num[13]["depends_on_parsed"] == []
+    assert "depends_on_unparseable" not in by_num[13]
+
+    # #14: messy depends_on → parsed contains 12 and 99 (5 was a typo,
+    # the fixture doesn't have it; let's just check 12 and 99 land)
+    assert 12 in by_num[14]["depends_on_parsed"]
+    assert 99 in by_num[14]["depends_on_parsed"]
+    assert "TBD-43" in by_num[14]["depends_on_unparseable"]
+    assert "#garbage" in by_num[14]["depends_on_unparseable"]
+
+    # #15: CLOSED past end_date → NOT delayed
+    assert "delay" not in by_num[15]
+    # #16: OPEN past end_date but no imp:baseline → NOT delayed
+    assert "delay" not in by_num[16]
+
+    # Top-level summary metrics
+    assert enriched["delayed_count"] == 1  # only #12
+    edges = enriched["dependency_edges"]
+    edge_pairs = {(e["from"], e["to"]) for e in edges}
+    assert (11, 10) in edge_pairs
+    assert (11, 9) in edge_pairs
+    assert (12, 11) in edge_pairs
+    assert (14, 12) in edge_pairs
+
+    print("test_enrich_full_payload_against_fixture: OK")
+
+
+# ---------- build_dependency_edges ----------
+
+
+def test_build_dependency_edges_skips_self_and_non_int() -> None:
+    issues = [
+        {"number": 1, "depends_on_parsed": [1, 2, 3]},  # 1→1 must be skipped
+        {"number": 2, "depends_on_parsed": []},
+        {"number": "not-an-int", "depends_on_parsed": [4]},  # whole issue skipped
+    ]
+    edges = h.build_dependency_edges(issues)
+    assert {(e["from"], e["to"]) for e in edges} == {(1, 2), (1, 3)}
+    print("test_build_dependency_edges_skips_self_and_non_int: OK")
+
+
+# ---------- runner ----------
+
+
+def main() -> None:
+    tests = [
+        test_parse_depends_on_basic_hash_csv,
+        test_parse_depends_on_strips_hash_and_whitespace,
+        test_parse_depends_on_empty_or_none,
+        test_parse_depends_on_collects_unparseable_without_aborting,
+        test_infer_duration_uses_github_value_when_present,
+        test_infer_duration_uses_label_hint_when_field_missing,
+        test_infer_duration_falls_back_to_default,
+        test_infer_duration_handles_zero_or_negative_as_missing,
+        test_detect_delay_returns_record_for_overdue_open_baseline_issue,
+        test_detect_delay_skips_closed_issue_even_if_overdue,
+        test_detect_delay_skips_issue_without_baseline_label,
+        test_detect_delay_skips_issue_without_end_date,
+        test_detect_delay_skips_when_end_date_in_future,
+        test_detect_delay_soft_skip_on_malformed_date,
+        test_enrich_issue_wraps_existing_fields_with_provenance,
+        test_enrich_issue_attaches_depends_on_parsed_array,
+        test_enrich_issue_attaches_delay_record_when_overdue,
+        test_enrich_issue_no_delay_key_when_not_delayed,
+        test_enrich_issue_does_not_mutate_input,
+        test_enrich_full_payload_against_fixture,
+        test_build_dependency_edges_skips_self_and_non_int,
+    ]
+    for t in tests:
+        t()
+    print(f"\nAll {len(tests)} heuristics tests passed.")
+
+
+if __name__ == "__main__":
+    try:
+        main()
+    except AssertionError as e:
+        print(f"\nFAIL: {e}")
+        sys.exit(1)
+    except Exception as e:
+        import traceback
+
+        print(f"\nERROR: {type(e).__name__}: {e}")
+        traceback.print_exc()
+        sys.exit(1)


### PR DESCRIPTION
## Summary

Closes KKallas/Imp#13. Reads `.imp/issues.json` (P4.12 sync output), infers missing fields, and writes `.imp/enriched.json` for downstream chart rendering and scenario analysis. Read-only — runs entirely on the cached snapshot.

## What gets inferred

Each field in `issue.fields` is upgraded from a flat scalar to a provenance envelope:

```json
{
  "value": <whatever>,
  "source": "github" | "heuristic" | "llm",
  "confidence": "high" | "medium" | "low"
}
```

- **duration_days** — github value if present (high confidence), else the **largest** matching label hint (medium confidence — largest-wins is intentional: for a PM tool, overestimate not underestimate, and it decouples from GitHub's label display order). Falls back to a 3-day global default at low confidence.
- **depends_on** — text like `"#12, #15"` parsed into `[12, 15]`. Per the AC, unparseable tokens are **logged but do NOT abort the run**. They land in `depends_on_unparseable` so the chart layer can mention them.
- **delay** — only attached when the issue is `OPEN`, has the `imp:baseline` label, and its `end_date` has passed. Includes `days_overdue` and `baseline_end_date`.

Plus three top-level enriched payload keys for downstream consumers:
- `dependency_edges` — `[{from: 12, to: 11}, ...]` ready for graph layout
- `delayed_count` — shorthand for the delay-aware chart templates
- `enriched_at` — fresh ISO timestamp; the original `synced_at` is propagated unchanged so callers can detect stale enrichment vs. stale sync independently.

## Acceptance criteria (from KKallas/Imp#13)

- [x] `depends_on` text field is parsed; unparseable values are logged but do NOT abort the sync — `parse_depends_on` returns `(parsed, unparseable)`; `enrich_issue` logs to stderr and proceeds.
- [x] Each enriched field carries `source` + `confidence` — provenance envelope on every field.
- [x] Detects delayed issues by comparing current `end_date` to `imp:baseline` label state — `detect_delay` requires OPEN + imp:baseline + end_date in the past.
- [x] Has unit tests against fixtures in `tests/fixtures/` — `tests/fixtures/sample_issues.json` with six representative issues, exercised by `test_enrich_full_payload_against_fixture`.

## Test plan

- [x] `.venv/bin/python tests/test_heuristics.py` — 21/21 pass (helpers + full fixture enrichment + edge cases)
- [x] `.venv/bin/python tests/test_sync_issues.py` — 15/15 pass (unchanged)
- [x] `.venv/bin/python tests/test_foreman_agent.py` — 24/24 pass
- [x] `.venv/bin/python tests/test_dispatcher.py` — 26/26 pass
- [x] `.venv/bin/python tests/test_setup_agent.py` — 24/24 pass
- [x] `.venv/bin/python tests/test_project_bootstrap.py` — 15/15 pass
- [x] `.venv/bin/python tests/test_budgets.py` — 18/18 pass
- [x] `.venv/bin/python tests/test_intercept.py` — 12/12 pass
- [x] `.venv/bin/python tests/test_guard.py` — 18/18 pass
- [x] Manual end-to-end: `python pipeline/sync_issues.py && python pipeline/heuristics.py && jq '.delayed_count, .dependency_edges | length' .imp/enriched.json`

🤖 Generated with [Claude Code](https://claude.com/claude-code)