### PR TITLE
[P4.14b] charts render inline via cl.Plotly (mermaid wasn't rendering)

### DIFF
--- a/main.py
+++ b/main.py
@@ -737,6 +737,7 @@ async def _on_message_body(msg: cl.Message) -> None:
         say=_foreman_say,
         ask=_foreman_ask,
         thinking=_foreman_thinking,
+        chart=_foreman_chart,
     )
 
 
@@ -776,6 +777,46 @@ async def _foreman_thinking(label: str):
     """
     async with cl.Step(name=label, type="run") as step:
         yield step
+
+
+async def _foreman_chart(artifact: dict) -> None:
+    """Render a chart artifact inline in chat.
+
+    Foreman's `run_render_chart` tool body pushes `{type, name, path}`
+    descriptors into a per-turn collector; `dispatch()` calls this
+    once per descriptor after the SDK loop finishes. Today only
+    `type=="plotly"` is wired (Chainlit 2.x has no mermaid renderer);
+    extend the dispatch table when other element types make sense.
+    """
+    import plotly.graph_objects as go
+
+    artifact_type = artifact.get("type")
+    if artifact_type != "plotly":
+        await cl.Message(
+            author="Foreman",
+            content=f"_(Skipped chart artifact of unknown type: {artifact_type!r})_",
+        ).send()
+        return
+
+    path = artifact.get("path")
+    if not path:
+        return
+    try:
+        figure_dict = json.loads(Path(path).read_text())
+    except (OSError, json.JSONDecodeError) as exc:
+        await cl.Message(
+            author="Foreman",
+            content=f"_(Couldn't load chart from `{path}`: {exc})_",
+        ).send()
+        return
+
+    figure = go.Figure(figure_dict)
+    name = artifact.get("name") or "chart"
+    await cl.Message(
+        author="Foreman",
+        content="",
+        elements=[cl.Plotly(name=name, figure=figure, display="inline")],
+    ).send()
 
 
 # ---------- real intercept demo (P2.6) ----------

--- a/pipeline/render_chart.py
+++ b/pipeline/render_chart.py
@@ -319,6 +319,118 @@ def build_context_for_gantt(enriched: dict[str, Any]) -> dict[str, Any]:
     }
 
 
+# ---------- Plotly figure (for inline chat rendering via cl.Plotly) ----------
+#
+# Chainlit 2.x has no native mermaid renderer, so the mermaid block in
+# the standalone HTML doesn't render in chat. We also produce a Plotly
+# Figure JSON next to it, which `server/foreman_agent.py` attaches to
+# the chat reply via `cl.Plotly` for an inline interactive chart.
+
+
+def build_plotly_figure(enriched: dict[str, Any]) -> dict[str, Any]:
+    """Build a Plotly Figure dict (JSON-serializable) for the gantt.
+
+    Returns a dict with `data` and `layout` keys — the canonical Plotly
+    JSON shape that `cl.Plotly(figure=Figure(...))` consumes after a
+    `plotly.graph_objects.Figure(**dict)` rehydrate.
+
+    Each renderable issue becomes a horizontal bar between its start
+    and end. Closed issues are coloured green; delayed (open + past
+    end_date + imp:baseline) are red; everything else is blue. Hover
+    text includes the issue number, title, and section.
+    """
+    _, renderable, _ = build_mermaid_gantt(enriched)
+
+    if not renderable:
+        # Empty figure with a friendly placeholder title — Chainlit
+        # still renders it, just nothing to chart yet.
+        return {
+            "data": [],
+            "layout": {
+                "title": {
+                    "text": (
+                        f"{enriched.get('repo', 'Project')} — no datable "
+                        "issues yet"
+                    )
+                },
+                "xaxis": {"type": "date"},
+                "yaxis": {"visible": False},
+                "height": 200,
+            },
+        }
+
+    # Sort by start date so the chart reads top-to-bottom in time order.
+    sorted_issues = sorted(renderable, key=lambda it: it["start"])
+
+    bars: list[dict[str, Any]] = []
+    for it in sorted_issues:
+        if it.get("delayed"):
+            colour = "#dc2626"  # red
+        elif (it.get("state") or "").upper() == "CLOSED":
+            colour = "#10b981"  # green
+        else:
+            colour = "#3b82f6"  # blue
+
+        label = f"#{it['number']} {it['title'][:60]}"
+        hover = (
+            f"<b>#{it['number']}</b> {it['title']}<br>"
+            f"Section: {it['section']}<br>"
+            f"{it['start']} → {it['end']}<br>"
+            f"State: {it.get('state', 'unknown')}"
+            + (
+                f"<br>Dependencies: {', '.join(f'#{d}' for d in it['dependencies'])}"
+                if it.get("dependencies")
+                else ""
+            )
+        )
+        bars.append(
+            {
+                "type": "bar",
+                "orientation": "h",
+                "x": [_days_between(it["start"], it["end"])],
+                "y": [label],
+                "base": [it["start"]],
+                "marker": {"color": colour},
+                "hovertemplate": hover + "<extra></extra>",
+                "showlegend": False,
+            }
+        )
+
+    layout = {
+        "title": {
+            "text": (
+                f"{enriched.get('repo', 'Project')} — Gantt"
+                + (
+                    f" ({enriched.get('delayed_count', 0)} delayed)"
+                    if enriched.get("delayed_count")
+                    else ""
+                )
+            )
+        },
+        "barmode": "stack",
+        "xaxis": {"type": "date", "title": {"text": "Timeline"}},
+        "yaxis": {
+            "title": {"text": "Issue"},
+            "automargin": True,
+            "autorange": "reversed",
+        },
+        "height": max(220, 30 * len(sorted_issues) + 120),
+        "margin": {"l": 20, "r": 20, "t": 60, "b": 40},
+    }
+
+    return {"data": bars, "layout": layout}
+
+
+def _days_between(start_iso: str, end_iso: str) -> int:
+    """Inclusive day count between two ISO dates, min 1."""
+    try:
+        s = date.fromisoformat(start_iso)
+        e = date.fromisoformat(end_iso)
+        return max(1, (e - s).days)
+    except ValueError:
+        return 1
+
+
 # Per-template context builders. Add new entries as kanban /
 # burndown / comparison templates land in later phases.
 CONTEXT_BUILDERS: dict[str, Any] = {
@@ -341,6 +453,18 @@ def write_html(html: str, template_name: str, output_dir: Path = OUTPUT_DIR) -> 
     output_dir.mkdir(parents=True, exist_ok=True)
     path = output_dir / f"{template_name}.html"
     path.write_text(html)
+    return path
+
+
+def write_plotly_json(
+    figure: dict[str, Any],
+    template_name: str,
+    output_dir: Path = OUTPUT_DIR,
+) -> Path:
+    """Persist the Plotly Figure JSON for `cl.Plotly` to consume from chat."""
+    output_dir.mkdir(parents=True, exist_ok=True)
+    path = output_dir / f"{template_name}.plotly.json"
+    path.write_text(json.dumps(figure, indent=2))
     return path
 
 
@@ -389,16 +513,34 @@ def main() -> int:
 
     context = builder(enriched)
     html = render_html(args.template, context)
-    out = write_html(html, args.template, args.output_dir)
+    html_path = write_html(html, args.template, args.output_dir)
+
+    # Also produce a Plotly Figure JSON so the chat layer can render
+    # the chart inline via cl.Plotly. Only meaningful for gantt today;
+    # other templates can opt in by adding their own builder + a
+    # PLOTLY_BUILDERS entry below.
+    plotly_path: Path | None = None
+    plotly_builder = PLOTLY_BUILDERS.get(args.template)
+    if plotly_builder is not None:
+        figure = plotly_builder(enriched)
+        plotly_path = write_plotly_json(figure, args.template, args.output_dir)
 
     print(
         f"Rendered {args.template} chart with {len(context.get('renderable_issues') or [])} "
         f"issues, {len(context.get('missing_issues') or [])} missing dates "
-        f"→ {out}",
+        f"→ {html_path}"
+        + (f" + {plotly_path}" if plotly_path else ""),
         file=sys.stderr,
     )
-    print(str(out))
+    print(str(html_path))
     return 0
+
+
+# Per-template Plotly figure builders. Add entries as new chart types
+# get inline-renderable Plotly equivalents.
+PLOTLY_BUILDERS: dict[str, Any] = {
+    "gantt": build_plotly_figure,
+}
 
 
 if __name__ == "__main__":

--- a/server/foreman_agent.py
+++ b/server/foreman_agent.py
@@ -62,6 +62,14 @@ from . import budgets, intercept
 
 ROOT = Path(__file__).resolve().parent.parent
 CONFIG_FILE = ROOT / ".imp" / "config.json"
+OUTPUT_DIR = ROOT / ".imp" / "output"
+
+# Module-level artifact collector — populated by tool bodies that
+# produce chat-renderable side outputs (currently: chart Plotly JSONs).
+# `dispatch()` clears this at the start of every turn and reads it at
+# the end so it can pass artifact descriptors to the UI layer via the
+# `chart` callable. Tests reset it via `_pending_artifacts.clear()`.
+_pending_artifacts: list[dict[str, Any]] = []
 
 
 # ---------- config I/O (local copy — server.setup_agent has another
@@ -407,12 +415,32 @@ async def do_run_heuristics(*, user_intent: str) -> dict[str, Any]:
 async def do_run_render_chart(
     template: str, *, user_intent: str
 ) -> dict[str, Any]:
-    """pipeline/render_chart.py — renders gantt/kanban/burndown/comparison.
-    Blocked on KKallas/Imp#14 (P4.14)."""
+    """Render a chart via `pipeline/render_chart.py`.
+
+    On success, also picks up the `.plotly.json` the script writes
+    alongside the HTML and pushes it into the module-level
+    `_pending_artifacts` collector. `dispatch()` reads that after the
+    turn and forwards it to the UI layer via the `chart` callable so
+    the chart renders inline in chat (Chainlit 2.x doesn't render
+    mermaid blocks; Plotly is the path that works today).
+    """
     argv = [sys.executable, "pipeline/render_chart.py", "--template", template]
-    return await do_run_shell(
+    result = await do_run_shell(
         argv, user_intent=user_intent, rationale=f"render {template} chart"
     )
+
+    if result.get("exit_code") == 0 and result.get("verdict") != "reject":
+        plotly_path = OUTPUT_DIR / f"{template}.plotly.json"
+        if plotly_path.exists():
+            _pending_artifacts.append(
+                {
+                    "type": "plotly",
+                    "name": template,
+                    "path": str(plotly_path),
+                }
+            )
+
+    return result
 
 
 async def do_run_scenario(
@@ -552,9 +580,13 @@ tools when possible; fall back to this only when no named tool fits.
 
 ## How you respond
 
-Plain markdown. When you produce a chart via `run_render_chart`, embed \
-the result as a mermaid fenced code block in your reply — Chainlit \
-renders it inline. Keep replies concise; the admin reads quickly.
+Plain markdown. When you call `run_render_chart`, the chart is \
+attached to your reply automatically as an interactive Plotly figure \
+— **don't paste mermaid or other chart syntax into your prose**, and \
+don't embed a code fence with the chart text. Just describe what the \
+chart shows in a sentence or two so the admin knows what they're \
+looking at, then let the attached figure do the rest. Keep replies \
+concise; the admin reads quickly.
 """
 
 
@@ -920,6 +952,11 @@ _DISALLOWED_TOOLS: tuple[str, ...] = (
 SayFn = Callable[[str], Awaitable[None]]
 AskFn = Callable[[str], Awaitable[Optional[str]]]
 ThinkingFn = Callable[[str], Any]
+# `chart(artifact)` is called once per chart artifact produced during
+# the turn. The UI layer picks the right Chainlit element from the
+# artifact descriptor (`{type, name, path}`) — main.py wires this to
+# `cl.Plotly` for `type=="plotly"`. None disables chart rendering.
+ChartFn = Callable[[dict[str, Any]], Awaitable[None]]
 
 
 class _NullAsyncContext:
@@ -936,6 +973,7 @@ async def dispatch(
     say: SayFn,
     ask: AskFn,
     thinking: Optional[ThinkingFn] = None,
+    chart: Optional[ChartFn] = None,
 ) -> None:
     """Run one Foreman conversation turn for `user_text`.
 
@@ -946,7 +984,14 @@ async def dispatch(
 
     The `thinking` seam brackets the SDK call with a cl.Step spinner
     in the UI layer (same pattern as dispatcher.py's synthesis turn).
+    The `chart` seam receives any chart artifacts produced by tool
+    calls (currently `run_render_chart`) so they render inline in
+    chat — Chainlit doesn't render mermaid blocks, so we render them
+    as `cl.Plotly` figures instead.
     """
+    # Reset the per-turn artifact collector so this dispatch only sees
+    # charts created by its own tool calls.
+    _pending_artifacts.clear()
     import sys
 
     print(f"[foreman] dispatch called: user_text={user_text!r}", file=sys.stderr)
@@ -1055,8 +1100,22 @@ async def dispatch(
                 f"but produced no prose reply. Ask a follow-up for a summary.)_"
             )
 
+    # Emit any chart artifacts collected during the turn. The chart
+    # callable is responsible for translating each descriptor into a
+    # Chainlit element (cl.Plotly for `type=="plotly"`).
+    if chart is not None and _pending_artifacts:
+        for artifact in list(_pending_artifacts):
+            try:
+                await chart(artifact)
+            except Exception as exc:  # noqa: BLE001 — don't let chart UI bugs swallow the turn
+                print(
+                    f"[foreman] chart render failed for {artifact!r}: "
+                    f"{type(exc).__name__}: {exc}",
+                    file=sys.stderr,
+                )
+
     print(
         f"[foreman] dispatch complete: tool_calls={tool_calls_seen} "
-        f"reply_chars={len(reply)}",
+        f"reply_chars={len(reply)} chart_artifacts={len(_pending_artifacts)}",
         file=sys.stderr,
     )

--- a/tests/test_foreman_agent.py
+++ b/tests/test_foreman_agent.py
@@ -313,8 +313,7 @@ async def test_do_run_fix_prs() -> None:
 
 
 async def test_do_run_render_chart_builds_argv() -> None:
-    """run_render_chart forwards --template correctly. The script itself
-    doesn't exist yet (P4.14), but the wiring must be right."""
+    """run_render_chart forwards --template correctly."""
     _reset()
     _FAKE.script([(0, "<html>", FakeAction(classified_as="read"))])
     await foreman_agent.do_run_render_chart(template="gantt", user_intent="u")
@@ -323,6 +322,81 @@ async def test_do_run_render_chart_builds_argv() -> None:
     assert "--template" in argv
     assert "gantt" in argv
     print("test_do_run_render_chart_builds_argv: OK")
+
+
+async def test_do_run_render_chart_collects_plotly_artifact() -> None:
+    """When the script writes .imp/output/<template>.plotly.json,
+    do_run_render_chart pushes a Plotly artifact descriptor into the
+    module-level collector that dispatch() reads after the turn."""
+    _reset()
+    foreman_agent._pending_artifacts.clear()
+
+    # Redirect OUTPUT_DIR to a tempdir so we can plant a fake artifact
+    # without touching the real .imp/output/.
+    tmp_output = Path(tempfile.mkdtemp(prefix="imp-foreman-chart-"))
+    foreman_agent.OUTPUT_DIR = tmp_output
+    fake_plotly = tmp_output / "gantt.plotly.json"
+    fake_plotly.write_text('{"data": [], "layout": {}}')
+
+    _FAKE.script(
+        [(0, "rendered ok", FakeAction(classified_as="read", verdict="approve"))]
+    )
+
+    await foreman_agent.do_run_render_chart(template="gantt", user_intent="u")
+
+    assert len(foreman_agent._pending_artifacts) == 1
+    art = foreman_agent._pending_artifacts[0]
+    assert art["type"] == "plotly"
+    assert art["name"] == "gantt"
+    assert art["path"] == str(fake_plotly)
+    print("test_do_run_render_chart_collects_plotly_artifact: OK")
+
+
+async def test_do_run_render_chart_no_artifact_on_failure() -> None:
+    """A failed render (rc != 0) must NOT push an artifact, even if a
+    stale .plotly.json from a prior run happens to be on disk."""
+    _reset()
+    foreman_agent._pending_artifacts.clear()
+
+    tmp_output = Path(tempfile.mkdtemp(prefix="imp-foreman-chart-fail-"))
+    foreman_agent.OUTPUT_DIR = tmp_output
+    (tmp_output / "gantt.plotly.json").write_text('{"data": [], "layout": {}}')
+
+    _FAKE.script(
+        [(1, "boom", FakeAction(classified_as="read", verdict="approve", returncode=1))]
+    )
+
+    await foreman_agent.do_run_render_chart(template="gantt", user_intent="u")
+    assert foreman_agent._pending_artifacts == []
+    print("test_do_run_render_chart_no_artifact_on_failure: OK")
+
+
+async def test_do_run_render_chart_no_artifact_on_rejection() -> None:
+    """A guard/budget rejection must NOT push an artifact even if rc==0."""
+    _reset()
+    foreman_agent._pending_artifacts.clear()
+
+    tmp_output = Path(tempfile.mkdtemp(prefix="imp-foreman-chart-rej-"))
+    foreman_agent.OUTPUT_DIR = tmp_output
+    (tmp_output / "gantt.plotly.json").write_text('{"data": [], "layout": {}}')
+
+    _FAKE.script(
+        [
+            (
+                0,
+                "",
+                FakeAction(
+                    classified_as="read",
+                    verdict="reject",
+                    verdict_reason="hypothetical guard rejection",
+                ),
+            )
+        ]
+    )
+
+    await foreman_agent.do_run_render_chart(template="gantt", user_intent="u")
+    assert foreman_agent._pending_artifacts == []
+    print("test_do_run_render_chart_no_artifact_on_rejection: OK")
 
 
 # ---------- control tools (no intercept, pure config) ----------
@@ -457,6 +531,9 @@ async def amain() -> None:
         test_do_run_solve_issues,
         test_do_run_fix_prs,
         test_do_run_render_chart_builds_argv,
+        test_do_run_render_chart_collects_plotly_artifact,
+        test_do_run_render_chart_no_artifact_on_failure,
+        test_do_run_render_chart_no_artifact_on_rejection,
         test_do_loop_pause_and_resume,
         test_do_loop_scope_accepts_only_issues,
         test_do_loop_scope_rejects_empty,

--- a/tests/test_render_chart.py
+++ b/tests/test_render_chart.py
@@ -303,6 +303,54 @@ def test_write_html_creates_output_file() -> None:
     print("test_write_html_creates_output_file: OK")
 
 
+def test_build_plotly_figure_against_fixture() -> None:
+    """Plotly figure dict has the expected `data` + `layout` shape and
+    one bar per renderable issue."""
+    enriched = _load_enriched()
+    figure = rc.build_plotly_figure(enriched)
+    assert isinstance(figure, dict)
+    assert "data" in figure and "layout" in figure
+    bars = figure["data"]
+    # Fixture has 3 renderable issues after enrichment (heuristics fills
+    # in duration_days from label hints): #11, #12, #15.
+    # #16 also has end_date + heuristic duration → renderable.
+    assert len(bars) >= 2, len(bars)
+    # Each bar carries a Plotly-shaped marker + hovertemplate
+    for bar in bars:
+        assert bar["type"] == "bar"
+        assert bar["orientation"] == "h"
+        assert "marker" in bar and "color" in bar["marker"]
+        assert "hovertemplate" in bar
+    # The closed issue #11 should be coloured green
+    eleven_bar = next(b for b in bars if "#11" in b["y"][0])
+    assert eleven_bar["marker"]["color"] == "#10b981"
+    # The delayed issue #12 should be coloured red
+    twelve_bar = next(b for b in bars if "#12" in b["y"][0])
+    assert twelve_bar["marker"]["color"] == "#dc2626"
+    # Layout title mentions the repo
+    assert "KKallas/Imp" in figure["layout"]["title"]["text"]
+    print("test_build_plotly_figure_against_fixture: OK")
+
+
+def test_build_plotly_figure_empty_payload_yields_friendly_placeholder() -> None:
+    """No renderable issues → empty data + layout that hints at why."""
+    figure = rc.build_plotly_figure({"issues": [], "repo": "x/y"})
+    assert figure["data"] == []
+    assert "no datable" in figure["layout"]["title"]["text"]
+    print("test_build_plotly_figure_empty_payload_yields_friendly_placeholder: OK")
+
+
+def test_write_plotly_json_creates_file() -> None:
+    enriched = _load_enriched()
+    figure = rc.build_plotly_figure(enriched)
+    path = rc.write_plotly_json(figure, "gantt", output_dir=_TMP_DIR)
+    assert path.exists()
+    assert path.suffix == ".json"
+    on_disk = json.loads(path.read_text())
+    assert on_disk["data"] == figure["data"]
+    print("test_write_plotly_json_creates_file: OK")
+
+
 def test_unknown_template_main_returns_error() -> None:
     """CLI: passing --template foo (with no foo.html.j2) returns rc=1."""
     # main() uses sys.argv via argparse; easiest path is to call the
@@ -334,6 +382,9 @@ def main() -> None:
         test_render_html_against_fixture_produces_valid_doc,
         test_render_html_no_renderable_issues_still_valid_doc,
         test_write_html_creates_output_file,
+        test_build_plotly_figure_against_fixture,
+        test_build_plotly_figure_empty_payload_yields_friendly_placeholder,
+        test_write_plotly_json_creates_file,
         test_unknown_template_main_returns_error,
     ]
     for t in tests:


### PR DESCRIPTION
## Summary

You hit the issue right after #43 landed: Foreman correctly emitted ` ```mermaid` blocks, but they showed as raw code in chat — Chainlit 2.x has **zero mermaid renderer** (confirmed by `grep -r mermaid` across the chainlit package). The system-prompt instruction was aspirational; reality requires a different rendering path.

This PR switches the inline-chat chart path to **Plotly via `cl.Plotly`** — the canonical Chainlit element for interactive charts, and `plotly` was already in `requirements.txt` waiting for exactly this. The standalone HTML at `.imp/output/<template>.html` keeps using mermaid (renders fine in a regular browser); the new `.imp/output/<template>.plotly.json` is the path the chat layer consumes.

## What changed

### `pipeline/render_chart.py`
- New `build_plotly_figure(enriched)` — horizontal bars sorted by start date. Closed → green, delayed → red, otherwise blue. Hovertemplate includes issue number, title, section, dates, dependencies.
- New `PLOTLY_BUILDERS` dispatch table mirrors the existing `CONTEXT_BUILDERS` so future templates (kanban / burndown / comparison) can opt in by registering their own builder.
- `main()` writes `.plotly.json` alongside the `.html` when a Plotly builder is registered.

### `server/foreman_agent.py`
- New module-level `_pending_artifacts` list collects chart descriptors `{type, name, path}` during a turn. `dispatch()` **clears it on entry** so each turn only sees its own charts.
- `do_run_render_chart` appends a Plotly artifact when the render succeeded **and** wasn't guard-rejected. Belt-and-suspenders so a stale `.plotly.json` on disk doesn't slip through after a failed turn.
- New optional `chart` UI seam in `dispatch()` — receives one descriptor per artifact after the SDK loop ends. Failures are caught and printed to stderr so a chart UI bug never swallows the whole turn.
- System prompt updated: **stop pasting mermaid**; let the attached figure speak for itself.

### `main.py`
- New `_foreman_chart(artifact)` rehydrates the JSON into a `plotly.graph_objects.Figure` and posts it as `cl.Plotly(display="inline")`.
- Wired into the `foreman_agent.dispatch` call as the `chart` argument.
- Unknown artifact types degrade gracefully with a small note. Load failures (missing file, bad JSON) surface in chat instead of silently failing.

## Tests

- `test_render_chart.py`: 3 new — Plotly shape against the fixture (closed→green, delayed→red verified), empty-payload placeholder, `write_plotly_json` round-trip. Now 21/21.
- `test_foreman_agent.py`: 3 new — artifact collected on success, **NOT** collected on rc=1, **NOT** collected on guard rejection. The three failure modes the chart layer must respect. Now 27/27.

**Full suite:** 21 + 27 + 21 + 15 + 26 + 24 + 15 + 18 + 12 + 18 = **197/197 pass**.

## Manual test plan

After both this and #43 merge:
1. Restart Chainlit
2. Ask Foreman: *"sync the issues, run heuristics, then make a gantt chart"*
3. Foreman should call `run_sync_issues` → `run_heuristics` → `run_render_chart(template="gantt")`
4. After Foreman's prose reply, an interactive Plotly Gantt should appear inline — pan, zoom, hover for issue details

## Base branch

Stacked on `p4.14/render-chart` (PR #43). GitHub will show a PR-into-PR diff. Merge #43 first; this auto-rebases onto main with no conflicts.

🤖 Generated with [Claude Code](https://claude.com/claude-code)