### PR TITLE
[P2.10] Guard reviews arbitrary code via Markdown checklist; allow python -c / bash -c

### DIFF
--- a/docs/guard_code_review.md
+++ b/docs/guard_code_review.md
@@ -1,0 +1,194 @@
+# Guard Agent — Code Review Checklist
+
+This file is the source of truth for how the Guard Agent (`server/guard.py`)
+reviews **arbitrary code** that Foreman proposes to run via `python -c`,
+`python3 -c`, `bash -c`, or `sh -c`. Loaded once at module import and
+embedded into the checkpoint-B system prompt — restart the server to pick
+up edits.
+
+The classifier in `server/intercept.py` is intentionally narrow; it
+recognises `gh`, named pipeline scripts, and a tiny demo-safe allowlist.
+Anything else falls into Guard's lap. For inline shell / Python code,
+Guard applies this checklist.
+
+Guard's job: read the proposed code + the user's stated intent, walk the
+checklist top to bottom, and emit a verdict. On reject, Guard MUST cite
+the specific rule that tripped (e.g. `"hard-reject — references ~/.ssh/"`)
+so the admin sees what failed and the worker can revise.
+
+---
+
+## 1. Hard reject (any one match → reject; cite the rule)
+
+### 1.1 Credential paths
+
+Reject if the code references any of these paths or matches:
+
+- `~/.ssh/`, `~/.aws/`, `~/.gcp/`, `~/.azure/`
+- `~/.gitconfig`, `~/.netrc`, `~/.npmrc`, `~/.pypirc`
+- `.env`, `.env.local`, `.env.production`
+- Browser profile dirs (`~/Library/Application Support/Google/Chrome/`,
+  `~/.config/google-chrome/`, equivalent for Firefox/Safari/Edge)
+- macOS Keychain (`security` CLI, `Keychain.framework`)
+- Linux secret stores (`gnome-keyring`, `kwallet`, `secret-tool`)
+
+Reject if the code reads environment variables matching any of:
+
+- `*_TOKEN`, `*_KEY`, `*_SECRET`, `*_PASSWORD`, `*_CREDENTIALS`
+- `GH_TOKEN`, `GITHUB_TOKEN`, `ANTHROPIC_API_KEY`, `OPENAI_API_KEY`
+- `AWS_ACCESS_KEY_ID`, `AWS_SECRET_ACCESS_KEY`, `AWS_SESSION_TOKEN`
+
+**Exception:** the code may *check whether a public env var exists* (e.g.
+`os.environ.get("PATH")`) — exfiltrating credentials is the concern, not
+introspection.
+
+### 1.2 Network egress
+
+Reject any outbound network call:
+
+- Python: `urllib`, `urllib2`, `urllib3`, `requests`, `httpx`, `aiohttp`,
+  `http.client`, `socket`, `ssl`, `paramiko`, `smtplib`, `ftplib`,
+  `telnetlib`, `xmlrpc.client`
+- Shell: `curl`, `wget`, `nc` / `netcat`, `ssh`, `scp`, `rsync`,
+  `ftp`/`sftp`, `nmap`, `dig`/`nslookup`/`host`
+- DNS lookups via `socket.gethostbyname` etc.
+
+Imp's pipelines reach GitHub via the `gh` CLI which IS allowed (it's
+classified separately and has its own auth). Direct GitHub API calls from
+arbitrary code are NOT — they bypass the gh classification path.
+
+### 1.3 Re-entrant shell / process spawning
+
+Reject anything that re-enters the shell:
+
+- `subprocess.*` with `shell=True`
+- `os.system`, `os.popen`, `os.spawn*`, `os.exec*`
+- `pty.spawn`, `pexpect.spawn`
+- `commands` module (Python 2 holdover, shouldn't appear)
+
+`subprocess.run([...], shell=False)` is **allowed** if the argv is a
+literal list and the command doesn't itself re-enter shell — but apply
+the rest of the checklist to the spawned command.
+
+### 1.4 Code generation / dynamic execution
+
+Reject:
+
+- `exec`, `eval`, `compile`
+- `__import__`, `importlib.import_module` with non-literal arg
+- `getattr(__builtins__, …)`, `getattr(builtins, …)`
+- `globals()[…]` / `locals()[…]` assignment
+- `marshal.loads`, `pickle.loads`, `dill.loads`, `cloudpickle.loads`
+  (deserialization is arbitrary code execution)
+- `base64`/`hex`/`zlib` decode of a literal followed by `exec`/`eval`/etc.
+
+### 1.5 Destructive filesystem ops outside `.imp/`
+
+Reject:
+
+- `shutil.rmtree`, `os.unlink`, `os.remove`, `os.rmdir`, `pathlib.Path.unlink`
+  on any path NOT under `.imp/`
+- `os.replace`, `os.rename`, `shutil.move` to/from outside `.imp/`
+- Shell `rm -rf` / `rm -r` on any path NOT under `.imp/`
+- `>` redirection to system files (`/etc/`, `/usr/`, `/bin/`, `/sbin/`,
+  `/var/`, `/opt/`, `~/Library/`, `~/.config/` outside `.imp/`)
+- `truncate`, `> /dev/null` on real files (the latter is fine in pipes)
+- `chmod -R` outside `.imp/`, `chown` (any), `setfacl`
+
+### 1.6 System config / privileged tooling
+
+Reject:
+
+- `sudo`, `su`, `doas`
+- `launchctl`, `systemctl`, `service`, `kill -9 <not-our-pid>`
+- Editing `/etc/`, `/Library/Preferences/`, `~/Library/LaunchAgents/`
+- `crontab`, `at`, `launchd` plist creation
+- `iptables`, `pfctl`, network interface manipulation
+- Package managers: `brew install`, `apt`, `yum`, `pacman`, `pip install`
+  to anywhere outside the project venv
+
+---
+
+## 2. Scope check (judgment call — apply when the hard-rejects all pass)
+
+For each proposed code action, Guard asks:
+
+1. **Does the code's apparent purpose match the user's intent for this
+   turn?** If the admin asked "moderate issue 42" and the code is
+   reading `.imp/issues.json`, that's plausibly on-task. If the code
+   touches issue 99 or PR 17, it's drifted.
+
+2. **Does it touch issues / PRs / files the admin didn't mention?**
+   Bias toward reject when in doubt — Foreman can revise with a
+   narrower scope.
+
+3. **Is the side effect proportional to the request?** Reading data is
+   cheap; writing files in `.imp/output/` is fine; writing files at the
+   repo root or under `99-tools/` is suspicious unless the admin
+   explicitly asked.
+
+A scope-check rejection isn't "this is malicious" — it's "this is
+broader than what was asked for." Cite as
+`"scope: code touches X but admin asked about Y"`.
+
+---
+
+## 3. Obfuscation flags (raise the rejection bar)
+
+Treat these as evidence the code is hiding something — apply the
+hard-reject and scope-check sections more strictly when present:
+
+- Long base64 string literals (>60 chars) decoded into something
+  executable
+- Long hex string literals (`bytes.fromhex(...)`)
+- `chr()` / `ord()` chains that build identifiers (`chr(115)+chr(104)` →
+  `"sh"`)
+- `getattr(obj, "x" + "yz")` — name built from string concatenation
+- `__getattribute__` / `__setattr__` indirection on builtins
+- Reflective module loading via string keys
+- Embedded zlib / gzip / lzma blobs decoded to source
+
+If the obfuscation is justified by the user's intent (e.g. admin asked
+to "decode this base64 and show me what it is"), it's fine — the test
+is whether the code's intent is HIDDEN from a human reader.
+
+---
+
+## 4. Commonly fine (for Guard's calibration)
+
+These patterns appear all the time and are typically benign — Guard
+shouldn't flag them unless something else trips:
+
+- Reading `.imp/*.json` (sync / heuristics output)
+- Writing under `.imp/output/*` or `.imp/sandbox/*`
+- Standard library reads: `json`, `re`, `datetime`, `pathlib`,
+  `collections`, `dataclasses`, `itertools`, `functools`
+- Computation: `statistics`, `math`, `decimal`, `fractions`
+- Text wrangling: `csv`, `string`, `textwrap`, `unicodedata`
+- Iteration helpers: `enumerate`, `zip`, `sorted`, `filter`, `map`
+- `print()` / writing to stdout/stderr (subprocess output is captured
+  by `intercept.py` and shown to the admin anyway)
+- `pathlib.Path.read_text()` / `write_text()` confined to `.imp/`
+
+If 100% of the code is in this list and the scope-check passes, approve
+without further analysis.
+
+---
+
+## 5. Verdict format
+
+Guard returns a single JSON object, no prose around it:
+
+```json
+{"verdict": "approve", "reason": "<short explanation>"}
+```
+
+or
+
+```json
+{"verdict": "reject", "reason": "hard-reject — <rule>: <evidence>"}
+```
+
+Reasons are capped at ~200 characters. On reject, the rule citation is
+mandatory so the admin sees which checklist item failed and the worker
+agent can revise its proposal.

--- a/server/guard.py
+++ b/server/guard.py
@@ -66,7 +66,11 @@ from __future__ import annotations
 
 import json
 import re
+from pathlib import Path
 from typing import Any, Awaitable, Callable, Optional
+
+ROOT = Path(__file__).resolve().parent.parent
+CODE_REVIEW_CHECKLIST_FILE = ROOT / "docs" / "guard_code_review.md"
 
 # ---------- pluggable backend ----------
 
@@ -223,6 +227,74 @@ can revise or abandon the action and the admin can see why it was blocked.
 """
 
 
+# ---------- arbitrary-code review (KKallas/Imp#46) ----------
+#
+# When the proposed action is `python -c "<code>"` or `bash -c "<cmd>"`,
+# the classifier in intercept.py routes it here as a "write" so Guard
+# reviews the code against the checklist in docs/guard_code_review.md.
+# The classifier whitelist is NOT the security boundary — Guard is.
+
+
+def _load_code_review_checklist() -> str:
+    """Read docs/guard_code_review.md once at module import.
+
+    Restart the server to pick up edits. We don't re-read on every check
+    because (a) it'd add disk I/O to every guard call and (b) hot-swapping
+    a security checklist mid-process is a pretty good way to ship subtle
+    bugs.
+    """
+    if CODE_REVIEW_CHECKLIST_FILE.exists():
+        return CODE_REVIEW_CHECKLIST_FILE.read_text()
+    return (
+        "# Guard Code Review Checklist (MISSING)\n\n"
+        "docs/guard_code_review.md was not found at module import. Guard\n"
+        "will fall back to its base prompt for arbitrary-code reviews,\n"
+        "which is less precise. Restore the file and restart to fix."
+    )
+
+
+CODE_REVIEW_CHECKLIST = _load_code_review_checklist()
+
+
+CHECKPOINT_B_CODE_SYSTEM_PROMPT = (
+    CHECKPOINT_B_SYSTEM_PROMPT
+    + "\n\n"
+    + "## Special case: arbitrary code (python -c / bash -c)\n\n"
+    + "The PROPOSED COMMAND below is INLINE CODE — `python -c \"<code>\"`,\n"
+    + "`python3 -c \"<code>\"`, `bash -c \"<cmd>\"`, or `sh -c \"<cmd>\"`.\n"
+    + "Apply the checklist below in addition to the on-task check above.\n"
+    + "The classifier in intercept.py is NOT a security boundary — you are.\n"
+    + "When you reject, your reason MUST cite the specific checklist rule\n"
+    + "that tripped, in the format `\"hard-reject — <rule>: <evidence>\"` or\n"
+    + "`\"scope: <what the code touches> vs <what the admin asked for>\"`.\n\n"
+    + "---\n\n"
+    + CODE_REVIEW_CHECKLIST
+)
+
+
+# Detection helpers — public so tests can exercise them and intercept.py
+# could (someday) reuse without duplicating regex.
+_INLINE_CODE_BASENAMES = ("python", "python3", "bash", "sh")
+
+
+def is_arbitrary_code_command(proposed_command: str) -> bool:
+    """True if the proposed command is `<basename> -c "<code>"` for one of
+    the inline-code shells we route through the checklist prompt.
+
+    `proposed_command` is the same string the LLM sees — already joined
+    by check() / check_action() from an argv list. We match on the first
+    two whitespace-separated tokens (basename + `-c`) and ignore the
+    payload itself.
+    """
+    if not isinstance(proposed_command, str):
+        return False
+    tokens = proposed_command.strip().split(maxsplit=2)
+    if len(tokens) < 2:
+        return False
+    basename = tokens[0].rsplit("/", 1)[-1]
+    return basename in _INLINE_CODE_BASENAMES and tokens[1] == "-c"
+
+
 # ---------- sanitization + parsing helpers ----------
 
 MAX_USER_TEXT_CHARS = 8000
@@ -365,9 +437,18 @@ async def check_action(
         "<<<END PROPOSED COMMAND>>>"
     )
 
+    # Pick the right system prompt: if this is arbitrary inline code
+    # (`python -c` / `bash -c`), embed the code-review checklist; for
+    # everything else (gh, named scripts), use the leaner base prompt.
+    # Saves tokens on actions Guard already handles cleanly.
+    if is_arbitrary_code_command(cmd):
+        system_prompt = CHECKPOINT_B_CODE_SYSTEM_PROMPT
+    else:
+        system_prompt = CHECKPOINT_B_SYSTEM_PROMPT
+
     backend = get_backend()
     try:
-        raw = await backend(CHECKPOINT_B_SYSTEM_PROMPT, user_prompt)
+        raw = await backend(system_prompt, user_prompt)
     except Exception as exc:  # noqa: BLE001 — fail closed on any backend error
         return (False, f"guard (checkpoint B) backend error: {exc}")
 

--- a/server/intercept.py
+++ b/server/intercept.py
@@ -165,8 +165,14 @@ def classify_command(argv: list[str]) -> ClassifyResult:
             return "read"
         return "unknown"
 
-    # python / python3 <script>
+    # python / python3 <script>  OR  python -c "<code>"
     if basename in ("python", "python3") and len(argv) >= 2:
+        # Inline `-c` code — KKallas/Imp#46. Classified as "write" so the
+        # Guard Agent reviews the code against the checklist in
+        # docs/guard_code_review.md before it runs. The classifier is NOT
+        # the security boundary here — Guard is.
+        if len(argv) >= 3 and argv[1] == "-c":
+            return "write"
         script = argv[1]
         for s in PIPELINE_READ_SCRIPTS:
             if script.endswith(s):
@@ -175,6 +181,10 @@ def classify_command(argv: list[str]) -> ClassifyResult:
             if script.endswith(s):
                 return "write"
         return "unknown"
+
+    # bash / sh -c "<cmd>" — same Guard-reviewed path as python -c.
+    if basename in ("bash", "sh") and len(argv) >= 3 and argv[1] == "-c":
+        return "write"
 
     # 99-tools/run_all.sh directly
     if cmd.endswith("/run_all.sh") or basename == "run_all.sh":

--- a/tests/test_guard.py
+++ b/tests/test_guard.py
@@ -332,6 +332,138 @@ async def test_check_returns_tuple_shape() -> None:
     print("test_check_returns_tuple_shape: OK")
 
 
+# ---------- code-review checklist (KKallas/Imp#46) ----------
+
+
+def test_is_arbitrary_code_command_recognises_inline_shells() -> None:
+    """python -c / python3 -c / bash -c / sh -c are inline-code, regardless
+    of an absolute-path prefix on the interpreter."""
+    cases = [
+        ('python3 -c "print(1)"', True),
+        ('python -c "x"', True),
+        ('bash -c "ls"', True),
+        ('sh -c "echo"', True),
+        ("/usr/bin/python3 -c x", True),
+        ("/opt/homebrew/bin/python -c y", True),
+        # Not inline-code:
+        ("gh issue list", False),
+        ("python pipeline/sync_issues.py", False),
+        ("echo hi", False),
+        ("", False),
+        ("python", False),  # too few tokens
+        ("python -m foo", False),  # -m is not -c
+    ]
+    for cmd, expected in cases:
+        got = guard.is_arbitrary_code_command(cmd)
+        assert got == expected, f"is_arbitrary_code_command({cmd!r}) → {got}, expected {expected}"
+    print("test_is_arbitrary_code_command_recognises_inline_shells: OK")
+
+
+def test_code_review_checklist_loaded_at_import() -> None:
+    """The Markdown checklist file is read once at module import and
+    embedded in the code-review variant of the checkpoint-B prompt."""
+    assert guard.CODE_REVIEW_CHECKLIST_FILE.exists(), (
+        "docs/guard_code_review.md must exist for Guard to load it"
+    )
+    assert "Hard reject" in guard.CODE_REVIEW_CHECKLIST
+    assert "Network egress" in guard.CODE_REVIEW_CHECKLIST
+    assert "Credential paths" in guard.CODE_REVIEW_CHECKLIST
+    # The checklist content must end up inside the code-review prompt
+    assert guard.CODE_REVIEW_CHECKLIST in guard.CHECKPOINT_B_CODE_SYSTEM_PROMPT
+    # And NOT inside the base prompt — that's the whole point of the split
+    assert guard.CODE_REVIEW_CHECKLIST not in guard.CHECKPOINT_B_SYSTEM_PROMPT
+    print("test_code_review_checklist_loaded_at_import: OK")
+
+
+async def test_check_action_uses_code_prompt_for_inline_python() -> None:
+    """When proposed_command is `python3 -c <code>`, check_action must
+    feed the code-review-augmented system prompt to the backend (not the
+    leaner base prompt)."""
+    captured = {"system": None}
+
+    async def capturing_backend(system_prompt: str, user_prompt: str) -> str:
+        captured["system"] = system_prompt
+        return '{"verdict": "approve", "reason": "fake"}'
+
+    guard.set_backend(capturing_backend)
+    try:
+        await guard.check_action(
+            user_intent="count the open issues",
+            proposed_command='python3 -c "import json; print(len(json.load(open(\'.imp/issues.json\'))))"',
+            worker_rationale="quick count from the cached sync",
+        )
+    finally:
+        guard.set_backend(None)
+
+    sys_prompt = captured["system"] or ""
+    assert "code review checklist" in sys_prompt.lower(), (
+        "expected the code-review prompt for an inline `python -c` action"
+    )
+    # Spot-check the actual checklist content made it through, not just
+    # the heading wrapper.
+    assert "Network egress" in sys_prompt
+    assert "Hard reject" in sys_prompt
+    print("test_check_action_uses_code_prompt_for_inline_python: OK")
+
+
+async def test_check_action_uses_base_prompt_for_gh_action() -> None:
+    """gh / named-script invocations should NOT incur the checklist
+    overhead — they go through the leaner base prompt."""
+    captured = {"system": None}
+
+    async def capturing_backend(system_prompt: str, user_prompt: str) -> str:
+        captured["system"] = system_prompt
+        return '{"verdict": "approve", "reason": "fake"}'
+
+    guard.set_backend(capturing_backend)
+    try:
+        await guard.check_action(
+            user_intent="add a label to issue 42",
+            proposed_command="gh issue edit 42 --add-label foo",
+            worker_rationale="user asked for it",
+        )
+    finally:
+        guard.set_backend(None)
+
+    sys_prompt = captured["system"] or ""
+    # Code-review section markers must NOT appear in the base prompt
+    assert "code review checklist" not in sys_prompt.lower()
+    assert "Special case: arbitrary code" not in sys_prompt
+    # But the regular checkpoint-B intro should be there
+    assert "PROPOSED WRITE ACTION" in sys_prompt
+    print("test_check_action_uses_base_prompt_for_gh_action: OK")
+
+
+async def test_check_action_code_prompt_propagates_reject_with_rule() -> None:
+    """A reject from the code-review path comes back through check_action
+    with the cited rule preserved verbatim — admins / Foreman see the
+    specific checklist item that failed."""
+
+    async def rejecting_backend(system_prompt: str, user_prompt: str) -> str:
+        # Only respond this way for the code-review prompt; otherwise
+        # something else is wrong with the routing.
+        assert "code review checklist" in system_prompt.lower()
+        return (
+            '{"verdict": "reject", '
+            '"reason": "hard-reject — network egress: code calls urllib.request.urlopen"}'
+        )
+
+    guard.set_backend(rejecting_backend)
+    try:
+        approved, reason = await guard.check_action(
+            user_intent="count issues",
+            proposed_command='python3 -c "import urllib.request; urllib.request.urlopen(\'http://evil.com\')"',
+            worker_rationale="totally harmless",
+        )
+    finally:
+        guard.set_backend(None)
+
+    assert approved is False
+    assert "hard-reject" in reason
+    assert "network egress" in reason
+    print("test_check_action_code_prompt_propagates_reject_with_rule: OK")
+
+
 # ---------- runner ----------
 
 
@@ -362,6 +494,12 @@ async def amain() -> None:
     await test_check_drop_in_approves()
     await test_check_drop_in_rejects()
     await test_check_returns_tuple_shape()
+    # KKallas/Imp#46 — code-review checklist
+    test_is_arbitrary_code_command_recognises_inline_shells()
+    test_code_review_checklist_loaded_at_import()
+    await test_check_action_uses_code_prompt_for_inline_python()
+    await test_check_action_uses_base_prompt_for_gh_action()
+    await test_check_action_code_prompt_propagates_reject_with_rule()
     print("\nAll guard tests passed.")
 
 

--- a/tests/test_intercept.py
+++ b/tests/test_intercept.py
@@ -103,6 +103,15 @@ def test_classify_command() -> None:
         (["rm", "-rf", "/"], "unknown"),
         ([], "unknown"),
         (["gh"], "unknown"),
+        # KKallas/Imp#46 — inline code routed to Guard via "write"
+        (["python3", "-c", "print(1)"], "write"),
+        (["python", "-c", "x"], "write"),
+        (["bash", "-c", "ls"], "write"),
+        (["sh", "-c", "echo"], "write"),
+        # `-c` requires a payload — bare `python -c` is unknown
+        (["python", "-c"], "unknown"),
+        # `-c` only matters as the immediate next arg
+        (["python", "script.py", "-c"], "unknown"),
     ]
     for argv, expected in cases:
         got = intercept.classify_command(argv)


### PR DESCRIPTION
## Summary

Closes KKallas/Imp#46. Foreman previously couldn't run `python3 -c "..."` or `bash -c "..."` even for read-only data wrangling — the classifier in `server/intercept.py` was acting as a security boundary instead of a token-saving optimization. Per v0.1.md the **Guard Agent** is the security boundary. This PR routes arbitrary inline code through Guard with a maintainable Markdown checklist.

## What changed

### `server/intercept.py`
`classify_command` now returns `"write"` for `python -c <code>` / `python3 -c <code>` / `bash -c <cmd>` / `sh -c <cmd>`. Bare `python -c` (no payload) and `python script.py -c` still classify as `"unknown"`. Other unrecognised commands (head/find/grep/etc.) are unchanged — that's a separate question if we want to relax it.

### `docs/guard_code_review.md` (new)
Source-of-truth checklist Guard reads at module import. Five sections:

1. **Hard reject** — credential paths, network egress, re-entrant shell, code generation, destructive FS ops outside `.imp/`, privileged tooling
2. **Scope check** — does the code match user intent? Does it touch issues/PRs/files the admin didn't mention?
3. **Obfuscation flags** — base64 / hex / chr-chains / getattr-by-name → raise the rejection bar
4. **Commonly fine** — calibration so Guard doesn't flag every `json.loads(open(".imp/issues.json").read())`
5. **Verdict format** — cite the rule on reject

Edits require a server restart (security checklists shouldn't hot-swap mid-process).

### `server/guard.py`
- Loads the checklist into `CODE_REVIEW_CHECKLIST` at import. Missing file → falls back with a loud error message embedded in the prompt instead of silently dropping the rules.
- New `CHECKPOINT_B_CODE_SYSTEM_PROMPT` — base prompt + special-case routing instruction + the full checklist.
- `is_arbitrary_code_command(proposed_command)` — public detection helper.
- `check_action()` picks the prompt: code-review for inline `python/bash -c`, leaner base prompt for everything else. **No extra tokens on actions Guard already handles cleanly** (gh, named scripts).

## Acceptance criteria

- [x] `intercept.classify_command` recognises `python3 -c <code>` and `bash -c <cmd>` as `"write"`
- [x] `docs/guard_code_review.md` exists with the four content sections (hard-reject, scope, obfuscation, commonly-fine)
- [x] `server/guard.py` loads `docs/guard_code_review.md` at module import and embeds it in the code-review variant of the checkpoint-B prompt
- [x] When Guard rejects an arbitrary-code action, the reason cites the specific rule (system prompt enforces the format; verified via `test_check_action_code_prompt_propagates_reject_with_rule`)
- [x] Existing `gh` / named-script invocations skip the code-review section of the prompt (`test_check_action_uses_base_prompt_for_gh_action`)
- [x] Tests for: intercept classification, checklist load, prompt routing both ways, reject-with-rule propagation

## Test plan

- [x] `.venv/bin/python tests/test_intercept.py` — 12/12 pass (6 new classification cases)
- [x] `.venv/bin/python tests/test_guard.py` — 23/23 pass (5 new for the code-review path)
- [x] `.venv/bin/python tests/test_render_chart.py` — 18/18 pass
- [x] `.venv/bin/python tests/test_heuristics.py` — 21/21 pass
- [x] `.venv/bin/python tests/test_sync_issues.py` — 15/15 pass
- [x] `.venv/bin/python tests/test_foreman_agent.py` — 24/24 pass
- [x] `.venv/bin/python tests/test_dispatcher.py` — 26/26 pass
- [x] `.venv/bin/python tests/test_setup_agent.py` — 24/24 pass
- [x] `.venv/bin/python tests/test_project_bootstrap.py` — 15/15 pass
- [x] `.venv/bin/python tests/test_budgets.py` — 18/18 pass
- [x] Manual: ask Foreman a question that requires data wrangling (e.g. "compute average duration from the closed issues"). Foreman should now be able to use `python -c` and Guard should approve / reject with a checklist citation.

🤖 Generated with [Claude Code](https://claude.com/claude-code)