### PR TITLE
[P9] P button opens chat with context — AI edits files through conversation

### DIFF
--- a/chat.html
+++ b/chat.html
@@ -859,7 +859,7 @@ async function loadWorkflows() {
           <span class="wf-item-status ${statusClass}">${icon} ${wf.status}</span>
           <button class="wf-start" ${canStart ? '' : 'disabled'} onclick="event.stopPropagation();startWorkflow('${wf.name}')">Start</button>
           <button class="wf-btn" onclick="event.stopPropagation();toggleEditWorkflow('${wf.name}')">${editingWorkflow === wf.name ? 'Done' : 'Edit'}</button>
-          <button class="wf-start" style="padding:3px 8px;font-size:11px;" onclick="event.stopPropagation();promptConfigureWorkflow('${wf.name}')" title="AI configures steps">P</button>
+          <button class="wf-start" style="padding:3px 8px;font-size:11px;" onclick="event.stopPropagation();promptWorkflow('${wf.name}')" title="AI edits workflow">P</button>
           <button class="wf-btn" onclick="event.stopPropagation();cloneWorkflow('${wf.name}')">Clone</button>
           <button class="wf-btn" onclick="event.stopPropagation();renameWorkflow('${wf.name}')">Rename</button>
           <button class="wf-btn" style="color:#da3633;border-color:#da3633;" onclick="event.stopPropagation();deleteWorkflow('${wf.name}')">Delete</button>
@@ -1034,26 +1034,22 @@ function removeStep(wfName, stepName) {
   }).then(() => loadWorkflows()).catch(e => alert('Remove failed: ' + e));
 }
 
-function promptConfigureWorkflow(name) {
-  const wfEl = document.querySelector(`[data-id="wf-${name}"]`);
-  if (!wfEl) return;
-  wfEl.open = true;
-  const body = wfEl.querySelector('.wf-body');
-  if (body) {
-    body.innerHTML = `<div style="padding:8px 16px 16px;">
-      <textarea class="wf-readme-edit" id="wf-prompt-area" style="min-height:80px;" placeholder="Instructions for AI (leave empty for auto-configure)..."></textarea>
-      <div style="margin-top:6px;display:flex;gap:8px;">
-        <button class="wf-start" style="font-size:11px;padding:4px 12px;" onclick="submitPromptWorkflow('${name}')">Run AI</button>
-        <button class="wf-btn" onclick="loadWorkflows()">Cancel</button>
-      </div>
-    </div>`;
-  }
-}
+async function promptWorkflow(name) {
+  if (!confirm(`Open AI chat for workflow "${name}"?`)) return;
 
-async function submitPromptWorkflow(name) {
-  const textarea = document.getElementById('wf-prompt-area');
-  const userPrompt = textarea ? textarea.value.trim() : '';
-  configureWorkflow(name, userPrompt);
+  const files = [`workflows/${name}/README.md`];
+  try {
+    const res = await fetch(`${API}/api/workflows/${name}`);
+    const data = await res.json();
+    for (const step of (data.steps || [])) {
+      const stepFile = step.file || `workflows/${name}/${step.name}.py`;
+      const rel = stepFile.includes('/workflows/') ? 'workflows/' + stepFile.split('/workflows/')[1] : stepFile;
+      files.push(rel);
+    }
+  } catch (e) {}
+
+  const instructions = `Edit this workflow based on the user's request. The workflow is in workflows/${name}/. You can modify the README, edit step scripts, add new steps, or remove steps. Each step has a run(context) function that receives previous_results.`;
+  await openChatWithContext(files, instructions, '');
 }
 
 async function configureWorkflow(name, userPrompt) {
@@ -1177,7 +1173,7 @@ async function loadToolsPanel() {
             ? `<div class="wf-readme">
                 <textarea class="wf-readme-edit" id="group-prompt-area" style="min-height:80px;" placeholder="Tell the AI what to write for this group description..."></textarea>
                 <div style="margin-top:6px;display:flex;gap:8px;">
-                  <button class="wf-start" style="font-size:11px;padding:4px 12px;" onclick="submitPromptGroup('${group}')">Run AI</button>
+                  <button class="wf-start" style="font-size:11px;padding:4px 12px;" onclick="submitPromptGroup('${group}')">Open Chat</button>
                   <button class="wf-btn" onclick="cancelPromptGroup()">Cancel</button>
                 </div>
               </div>`
@@ -1204,7 +1200,7 @@ async function loadToolsPanel() {
                   ${isToolPrompting
                     ? `<textarea class="wf-readme-edit" id="tool-prompt-area" style="min-height:80px;" placeholder="Tell the AI what to do with this tool..."></textarea>
                        <div style="margin-top:6px;display:flex;gap:8px;">
-                         <button class="wf-start" style="font-size:11px;padding:4px 12px;" onclick="submitPromptTool('${group}','${t.name}')">Run AI</button>
+                         <button class="wf-start" style="font-size:11px;padding:4px 12px;" onclick="submitPromptTool('${group}','${t.name}')">Open Chat</button>
                          <button class="wf-btn" onclick="cancelPromptTool()">Cancel</button>
                        </div>`
                     : isToolEditing
@@ -1287,41 +1283,35 @@ function cancelPromptTool() {
   loadToolsPanel();
 }
 
+async function openChatWithContext(files, instructions, userPrompt) {
+  try {
+    const res = await fetch(`${API}/api/chat/new-with-context`, {
+      method: 'POST', headers: {'Content-Type': 'application/json'},
+      body: JSON.stringify({files, instructions, user_prompt: userPrompt}),
+    });
+    const data = await res.json();
+    if (data.id) {
+      currentChatId = data.id;
+      switchTab('chat');
+      await loadChats();
+      // Select the new chat in sidebar
+      document.querySelectorAll('.chat-item').forEach(el => {
+        el.classList.toggle('active', el.dataset.id === data.id);
+      });
+    }
+  } catch (e) { alert('Failed to open chat: ' + e); }
+}
+
 async function submitPromptTool(group, name) {
   const textarea = document.getElementById('tool-prompt-area');
   if (!textarea) return;
   const userPrompt = textarea.value.trim();
   if (!userPrompt) { alert('Please enter instructions for the AI'); return; }
-
-  const mode = _promptingTool?.mode || 'describe';
   _promptingTool = null;
 
-  // Show spinner, hide buttons
-  const det = document.querySelector(`[data-id="tool-${group}-${name}"]`);
-  if (det) {
-    det.querySelectorAll('.wf-btn, .wf-start').forEach(b => b.style.display = 'none');
-    const container = det.querySelector('.wf-step-output');
-    if (container) container.innerHTML = '<div style="display:flex;align-items:center;gap:10px;padding:8px 0;"><div class="wf-spinner"></div><span style="font-size:12px;color:var(--muted);">AI is working...</span></div>';
-  }
-
-  try {
-    if (mode === 'describe') {
-      const res = await fetch(`${API}/api/tool-describe`, {
-        method: 'POST', headers: {'Content-Type': 'application/json'},
-        body: JSON.stringify({group, name, user_prompt: userPrompt}),
-      });
-      const data = await res.json();
-      if (data.error) alert('Failed: ' + data.error);
-    } else {
-      const res = await fetch(`${API}/api/tool-edit`, {
-        method: 'POST', headers: {'Content-Type': 'application/json'},
-        body: JSON.stringify({group, name, new_description: userPrompt, user_prompt: userPrompt}),
-      });
-      const data = await res.json();
-      if (data.error) alert('Failed: ' + data.error);
-    }
-  } catch (e) { alert('Failed: ' + e); }
-  loadToolsPanel();
+  const files = [`tools/${group}/${name}.py`, `tools/${group}/${name}.step.py`];
+  const instructions = `Edit this tool script and/or its workflow step template based on the user's request. The tool is tools/${group}/${name}.py. After making changes, the files will be updated on disk.`;
+  await openChatWithContext(files, instructions, userPrompt);
 }
 
 function openPromptGroup(group) {
@@ -1339,21 +1329,16 @@ async function submitPromptGroup(group) {
   if (!textarea) return;
   const userPrompt = textarea.value.trim();
   if (!userPrompt) { alert('Please enter instructions for the AI'); return; }
-
   _promptingGroup = null;
-  _describingGroup = group;
-  loadToolsPanel();
 
-  try {
-    const res = await fetch(`${API}/api/tool-group-describe`, {
-      method: 'POST', headers: {'Content-Type': 'application/json'},
-      body: JSON.stringify({group, user_prompt: userPrompt}),
-    });
-    const data = await res.json();
-    if (data.error) alert('Failed: ' + data.error);
-  } catch (e) { alert('Failed: ' + e); }
-  _describingGroup = null;
-  loadToolsPanel();
+  // Collect all tool files in the group
+  const groupTools = _toolsCache.filter(t => t.group === group);
+  const files = [`tools/${group}/README.md`];
+  for (const t of groupTools) {
+    files.push(`tools/${group}/${t.name}.py`);
+  }
+  const instructions = `Edit tools in the "${group}" group based on the user's request. You can modify the README, edit existing tool scripts, or create new ones. All files are under tools/${group}/.`;
+  await openChatWithContext(files, instructions, userPrompt);
 }
 
 async function describeToolGroup(group) {

--- a/chat.html
+++ b/chat.html
@@ -1118,8 +1118,6 @@ let _toolsCache = [];
 let _editingToolGroup = null;
 let _editingTool = null;  // {group, name}
 let _describingGroup = null;
-let _promptingTool = null;  // {group, name, mode: 'describe'|'edit'}
-let _promptingGroup = null; // group name
 
 async function loadToolsPanel() {
   const el = document.getElementById('tools-list-panel');
@@ -1149,19 +1147,18 @@ async function loadToolsPanel() {
 
       const isEditing = _editingToolGroup === group;
       const isDescribing = _describingGroup === group;
-      const isGroupPrompting = _promptingGroup === group;
       html += `<details class="wf-item" data-id="tg-${group}">
         <summary>
           <span class="wf-item-name">${group}</span>
           <span class="wf-item-meta">${tools.length} tools</span>
-          ${isDescribing || isGroupPrompting
+          ${isDescribing
             ? ``
             : isEditing
             ? `<button class="wf-btn" style="color:#3fb950;border-color:#3fb950;" onclick="event.stopPropagation();saveToolGroupReadme('${group}')">OK</button>
                <button class="wf-btn" onclick="event.stopPropagation();cancelToolGroupEdit()">Cancel</button>`
             : `<button class="wf-btn" onclick="event.stopPropagation();editToolGroup('${group}')">Edit</button>
                <button class="wf-btn" onclick="event.stopPropagation();describeToolGroup('${group}')">Tools→Desc</button>
-               <button class="wf-start" style="padding:3px 8px;font-size:11px;" onclick="event.stopPropagation();openPromptGroup('${group}')" title="Instruct AI">P</button>
+               <button class="wf-start" style="padding:3px 8px;font-size:11px;" onclick="event.stopPropagation();openPromptGroup('${group}')" title="AI Chat">P</button>
                <button class="wf-btn" onclick="event.stopPropagation();copyToolGroup('${group}')">Copy</button>
                <button class="wf-btn" onclick="event.stopPropagation();renameToolGroup('${group}')">Rename</button>
                <button class="wf-btn" style="color:#da3633;border-color:#da3633;" onclick="event.stopPropagation();deleteToolGroup('${group}')">Delete</button>`}
@@ -1169,21 +1166,12 @@ async function loadToolsPanel() {
         <div class="wf-body">
           ${isDescribing
             ? '<div class="wf-readme"><div style="display:flex;align-items:center;gap:10px;padding:8px 0;"><div class="wf-spinner"></div><span style="font-size:12px;color:var(--muted);">AI is generating group description...</span></div></div>'
-            : isGroupPrompting
-            ? `<div class="wf-readme">
-                <textarea class="wf-readme-edit" id="group-prompt-area" style="min-height:80px;" placeholder="Tell the AI what to write for this group description..."></textarea>
-                <div style="margin-top:6px;display:flex;gap:8px;">
-                  <button class="wf-start" style="font-size:11px;padding:4px 12px;" onclick="submitPromptGroup('${group}')">Open Chat</button>
-                  <button class="wf-btn" onclick="cancelPromptGroup()">Cancel</button>
-                </div>
-              </div>`
             : isEditing
             ? '<div class="wf-readme"><textarea class="wf-readme-edit" id="tg-readme-edit" style="min-height:150px;">'+rawReadme.replace(/</g,'&lt;').replace(/>/g,'&gt;')+'</textarea></div>'
             : (readmeHtml ? '<div class="wf-readme">' + readmeHtml + '</div>' : '')}
           <div class="wf-steps">
             ${tools.map(t => {
               const isToolEditing = _editingTool && _editingTool.group === group && _editingTool.name === t.name;
-              const isToolPrompting = _promptingTool && _promptingTool.group === group && _promptingTool.name === t.name;
               return `<details class="wf-step-item" data-id="tool-${group}-${t.name}">
                 <summary style="display:flex;align-items:center;gap:6px;">
                   <span style="flex:1;">${t.name}</span>
@@ -1192,18 +1180,12 @@ async function loadToolsPanel() {
                        <button class="wf-btn" onclick="event.stopPropagation();event.preventDefault();cancelToolScriptEdit()">Cancel</button>`
                     : `<button class="wf-btn" onclick="event.stopPropagation();event.preventDefault();editToolScript('${group}','${t.name}')">Edit</button>
                        <button class="wf-btn" onclick="event.stopPropagation();event.preventDefault();describeToolScript('${group}','${t.name}')">Code→Desc</button>
-                       <button class="wf-start" style="padding:3px 8px;font-size:11px;" onclick="event.stopPropagation();event.preventDefault();openPromptTool('${group}','${t.name}','describe')" title="Instruct AI">P</button>
+                       <button class="wf-start" style="padding:3px 8px;font-size:11px;" onclick="event.stopPropagation();event.preventDefault();openPromptTool('${group}','${t.name}')" title="AI Chat">P</button>
                        <button class="wf-btn" onclick="event.stopPropagation();event.preventDefault();copyToolScript('${group}','${t.name}')">Copy</button>
                        <button class="wf-btn" style="color:#da3633;border-color:#da3633;" onclick="event.stopPropagation();event.preventDefault();deleteToolScript('${group}','${t.name}')">Delete</button>`}
                 </summary>
-                <div class="wf-step-output" id="tool-detail-${group}-${t.name}" style="padding:8px 10px;" ${(isToolEditing || isToolPrompting) ? 'data-loaded="1"' : ''}>
-                  ${isToolPrompting
-                    ? `<textarea class="wf-readme-edit" id="tool-prompt-area" style="min-height:80px;" placeholder="Tell the AI what to do with this tool..."></textarea>
-                       <div style="margin-top:6px;display:flex;gap:8px;">
-                         <button class="wf-start" style="font-size:11px;padding:4px 12px;" onclick="submitPromptTool('${group}','${t.name}')">Open Chat</button>
-                         <button class="wf-btn" onclick="cancelPromptTool()">Cancel</button>
-                       </div>`
-                    : isToolEditing
+                <div class="wf-step-output" id="tool-detail-${group}-${t.name}" style="padding:8px 10px;" ${isToolEditing ? 'data-loaded="1"' : ''}>
+                  ${isToolEditing
                     ? `<div style="margin-bottom:8px;display:flex;align-items:center;gap:8px;">
                         <label style="font-size:12px;color:var(--muted);">Group:</label>
                         <select id="tool-move-group" style="padding:3px 8px;background:var(--input-bg);color:var(--fg);border:1px solid var(--border);border-radius:4px;font-size:12px;">
@@ -1232,16 +1214,6 @@ async function loadToolsPanel() {
       if (tgEl) tgEl.open = true;
       const tEl = el.querySelector(`[data-id="tool-${_editingTool.group}-${_editingTool.name}"]`);
       if (tEl) tEl.open = true;
-    }
-    if (_promptingTool) {
-      const tgEl = el.querySelector(`[data-id="tg-${_promptingTool.group}"]`);
-      if (tgEl) tgEl.open = true;
-      const tEl = el.querySelector(`[data-id="tool-${_promptingTool.group}-${_promptingTool.name}"]`);
-      if (tEl) tEl.open = true;
-    }
-    if (_promptingGroup) {
-      const tgEl = el.querySelector(`[data-id="tg-${_promptingGroup}"]`);
-      if (tgEl) tgEl.open = true;
     }
 
     // Lazy-load tool detail on toggle
@@ -1272,15 +1244,11 @@ async function loadToolsPanel() {
   } catch (e) { console.error('loadToolsPanel failed:', e); el.innerHTML = '<div style="padding:20px;color:#da3633;">Failed to load tools</div>'; }
 }
 
-function openPromptTool(group, name, mode) {
-  _promptingTool = {group, name, mode};
-  _editingTool = null;
-  loadToolsPanel();
-}
-
-function cancelPromptTool() {
-  _promptingTool = null;
-  loadToolsPanel();
+function openPromptTool(group, name) {
+  if (!confirm(`Open AI chat for ${group}/${name}?`)) return;
+  const files = [`tools/${group}/${name}.py`, `tools/${group}/${name}.step.py`];
+  const instructions = `Edit this tool script and/or its workflow step template based on the user's request. The tool is tools/${group}/${name}.py. After making changes, the files will be updated on disk.`;
+  openChatWithContext(files, instructions, '');
 }
 
 async function openChatWithContext(files, instructions, userPrompt) {
@@ -1302,43 +1270,16 @@ async function openChatWithContext(files, instructions, userPrompt) {
   } catch (e) { alert('Failed to open chat: ' + e); }
 }
 
-async function submitPromptTool(group, name) {
-  const textarea = document.getElementById('tool-prompt-area');
-  if (!textarea) return;
-  const userPrompt = textarea.value.trim();
-  if (!userPrompt) { alert('Please enter instructions for the AI'); return; }
-  _promptingTool = null;
-
-  const files = [`tools/${group}/${name}.py`, `tools/${group}/${name}.step.py`];
-  const instructions = `Edit this tool script and/or its workflow step template based on the user's request. The tool is tools/${group}/${name}.py. After making changes, the files will be updated on disk.`;
-  await openChatWithContext(files, instructions, userPrompt);
-}
 
 function openPromptGroup(group) {
-  _promptingGroup = group;
-  loadToolsPanel();
-}
-
-function cancelPromptGroup() {
-  _promptingGroup = null;
-  loadToolsPanel();
-}
-
-async function submitPromptGroup(group) {
-  const textarea = document.getElementById('group-prompt-area');
-  if (!textarea) return;
-  const userPrompt = textarea.value.trim();
-  if (!userPrompt) { alert('Please enter instructions for the AI'); return; }
-  _promptingGroup = null;
-
-  // Collect all tool files in the group
+  if (!confirm(`Open AI chat for "${group}" group?`)) return;
   const groupTools = _toolsCache.filter(t => t.group === group);
   const files = [`tools/${group}/README.md`];
   for (const t of groupTools) {
     files.push(`tools/${group}/${t.name}.py`);
   }
   const instructions = `Edit tools in the "${group}" group based on the user's request. You can modify the README, edit existing tool scripts, or create new ones. All files are under tools/${group}/.`;
-  await openChatWithContext(files, instructions, userPrompt);
+  openChatWithContext(files, instructions, '');
 }
 
 async function describeToolGroup(group) {

--- a/server/render_route.py
+++ b/server/render_route.py
@@ -222,6 +222,45 @@ async def create_chat():
     return {"id": session.id, "title": session.title}
 
 
+@app.post("/api/chat/new-with-context")
+async def new_chat_with_context(request: Request):
+    """Create a new chat session pre-loaded with file contents and instructions."""
+    from server import chat_history
+
+    data = await request.json()
+    files = data.get("files", [])
+    instructions = data.get("instructions", "")
+    user_prompt = data.get("user_prompt", "")
+
+    # Build context message with file contents
+    parts = []
+    if instructions:
+        parts.append(instructions)
+    for fpath in files:
+        full = _ROOT / fpath
+        if full.is_file():
+            try:
+                content = full.read_text()
+                parts.append(f"--- {fpath} ---\n```python\n{content}```")
+            except Exception:
+                parts.append(f"--- {fpath} --- (could not read)")
+
+    context_msg = "\n\n".join(parts)
+
+    # Create session with context as system preamble + user prompt
+    session = chat_history.ChatSession.new()
+    if context_msg:
+        session.append_turn("user", f"[CONTEXT]\n{context_msg}")
+        session.append_turn("assistant", "I have the files loaded. What would you like me to do?")
+    if user_prompt:
+        session.append_turn("user", user_prompt)
+    session.title = user_prompt[:50] if user_prompt else "AI edit session"
+    session.title_source = "agent"
+    chat_history.save_session(session)
+
+    return {"id": session.id, "title": session.title}
+
+
 @app.get("/api/chats/{chat_id}")
 async def get_chat(chat_id: str):
     from server import chat_history


### PR DESCRIPTION
## Summary
- **P button** on tools, tool groups, and workflows now opens a **new chat session** with relevant files pre-loaded
- `POST /api/chat/new-with-context` endpoint creates a session with file contents as initial context
- User types instructions → "Open Chat" → switches to Chat tab with files loaded → iterate with AI
- Replaces single-shot LLM calls with interactive conversation where user can course-correct

## What P loads per item type
| Item | Files loaded |
|------|-------------|
| Tool script | `tools/{group}/{name}.py` + `.step.py` |
| Tool group | `tools/{group}/README.md` + all scripts |
| Workflow | `workflows/{name}/README.md` + all step files |

## Test plan
- [ ] P on a tool → textarea → type instruction → Open Chat → Chat tab opens with tool code loaded
- [ ] P on a tool group → loads README + all tool scripts
- [ ] P on a workflow → loads README + all step files
- [ ] Chat shows file contents in first message, AI responds
- [ ] User can iterate and ask follow-ups
- [ ] New chat appears in sidebar

Closes #109

🤖 Generated with [Claude Code](https://claude.com/claude-code)