### PR TITLE
Fix chat response rendered twice

### DIFF
--- a/static/imp-chat.js
+++ b/static/imp-chat.js
@@ -173,8 +173,9 @@ function connectWs() {
 
       case 'done':
         if (currentAgentMsg && msg.full_text) {
-          if (!agentText.includes(msg.full_text) && msg.full_text) {
-            agentText += msg.full_text;
+          // Only use full_text as fallback when streaming delivered nothing
+          if (!agentText.trim()) {
+            agentText = msg.full_text;
           }
           renderAgentBody();
         }


### PR DESCRIPTION
## Summary

- Agent responses were duplicated in the chat UI because the `done` handler appended `full_text` even when streaming had already delivered the content
- The `includes()` check failed due to interleaved HTML tool/thinking blocks in `agentText`
- Now only uses `full_text` as a fallback when streaming delivered nothing

Fixes #114

## Test plan

- [x] Send a message that triggers tool calls + text response — should render once
- [x] Send a simple text-only message — should render once
- [x] Verify mermaid diagrams and tables appear only once

🤖 Generated with [Claude Code](https://claude.com/claude-code)