### PR TITLE
Lock panel only while agent is working

### DIFF
--- a/static/imp-tools.js
+++ b/static/imp-tools.js
@@ -115,7 +115,7 @@ async function loadToolsPanel() {
       });
     });
 
-    if (_chatSourceLock) {
+    if (_chatSourceLock && isWorking) {
       imp.applyLock(el, _chatSourceLock.id, 'AI is editing in Chat tab...');
     }
   } catch (e) { console.error('loadToolsPanel failed:', e); el.innerHTML = '<div style="padding:20px;color:#da3633;">Failed to load tools</div>'; }

--- a/static/imp-workflows.js
+++ b/static/imp-workflows.js
@@ -89,7 +89,7 @@ async function loadWorkflows() {
     el.innerHTML = html;
 
     imp.restoreOpenState(el, openState);
-    if (_chatSourceLock && _chatSourceLock.type === 'workflow') {
+    if (_chatSourceLock && _chatSourceLock.type === 'workflow' && isWorking) {
       imp.applyLock(el, _chatSourceLock.id, 'AI is editing in Chat tab...');
     }
   } catch (e) { console.error('loadWorkflows failed:', e); }


### PR DESCRIPTION
## Summary

- Panel locks only when agent is actively working (`isWorking`), not when chat is open
- User can browse/edit the workflow or tool panel while typing instructions

Fixes #121

🤖 Generated with [Claude Code](https://claude.com/claude-code)