### PR TITLE
Agent tools: workflow discovery + tool priority

### DIFF
--- a/README.md
+++ b/README.md
@@ -26,10 +26,36 @@ When you open the browser for the first time, a setup wizard in the Chat tab gui
 
 - Checking if the folder is a git repository
 - Connecting to GitHub via `gh` CLI
-- Linking or creating a GitHub repo
-- Setting up a project board
+- Naming your project, picking a license, writing a README
+- Creating a GitHub repo and pushing your files
+- Setting up branch protection (require PR approval)
 
 Other tabs (Queue, Workflows, Tools) are locked until setup completes. Once done, the full interface is available.
+
+## How it works
+
+Imp is deliberately simple. No MCP servers, no complex protocols, no middleware layers.
+
+```
+Browser (HTML + JS)
+    ↕ WebSocket
+FastAPI server (render_route.py)
+    ↕ claude-agent-sdk
+Claude (with native Bash, Read, Write tools)
+    ↕ subprocess
+gh CLI, git, python scripts in tools/
+```
+
+The agent talks to GitHub through `gh` commands. Tools are plain Python scripts with argparse. Workflows are folders of numbered step scripts. Everything the agent does is a shell command or a file read/write — the same things you'd do manually in a terminal.
+
+### Why no MCP
+
+MCP adds a protocol layer between the agent and the tools. Imp doesn't need it — the agent already has Bash access and can run any command directly. Keeping it simple means:
+
+- Fewer moving parts to break
+- Tools are just `.py` files you can run yourself
+- No protocol versioning, no server lifecycle, no tool registration
+- Easy to debug: if a tool works in your terminal, it works in Imp
 
 ## Usage
 

--- a/README.md
+++ b/README.md
@@ -1,87 +1,43 @@
 # Imp
 
-Ultra simple AI agent workflows for Claude Code to automate your GitHub repo. Create issues, run the scripts, get PRs. Make an LLM do the housekeeping and developemnt when you are busy.
+AI-powered project manager that lives inside your GitHub repo. Manage issues, run workflows, and chat with an AI agent — all from a single web interface.
 
-## Quick Start
+## Requirements
 
-### 1. Get the tools
+- Python 3.11 or newer
+- [GitHub CLI (`gh`)](https://cli.github.com/) installed and authenticated
 
-```bash
-cd your-project
-git clone https://github.com/KKallas/Imp.git /tmp/imp
-cp -r /tmp/imp/99-tools ./99-tools
-rm -rf /tmp/imp
+## Setup
+
+1. Copy the Imp folder into your project directory (or clone this repo)
+2. Run:
+
+```
+python imp.py
 ```
 
-### 2. Install requirements
+3. Open http://127.0.0.1:8421 in your browser
 
-```bash
-brew install gh && gh auth login       # GitHub CLI
-npm install -g @anthropic-ai/claude-code  # Claude CLI
-```
+That's it. On first run, Imp creates a virtual environment, installs dependencies, and starts the web server. No manual pip install needed.
 
-### 3. Describe your project
+## First run
 
-Open `99-tools/project_description.md` and describe what your project does, the tech stack, folder structure, how to build/test. The agents use this as context.
+When you open the browser for the first time, a setup wizard in the Chat tab guides you through:
 
-Tip: paste your codebase into any LLM and ask "write a project description for an AI agent that will work on this code."
+- Checking if the folder is a git repository
+- Connecting to GitHub via `gh` CLI
+- Linking or creating a GitHub repo
+- Setting up a project board
 
-### 4. Point to your repo
+Other tabs (Queue, Workflows, Tools) are locked until setup completes. Once done, the full interface is available.
 
-```bash
-export ROBOT_ARENA_REPO="your-org/your-repo"
-```
+## Usage
 
-### 5. Create issues on GitHub
+- **Queue** — work items awaiting your action
+- **Chat** — talk to the AI agent (powered by Claude) to manage your project
+- **Workflows** — multi-step automations (sync issues, triage, deploy)
+- **Tools** — reusable scripts the AI agent can call
 
-Just write issues like you normally would -- messy is fine:
+## License
 
-> "the login page is slow"
->
-> "add dark mode"
->
-> "fix the bug where users can submit empty forms"
-
-### 6. Run
-
-```bash
-./99-tools/run_all.sh --max-tasks 3
-```
-
-That's it. The agents will:
-1. Read your issues, ask clarifying questions, format them into structured tasks
-2. Pick up ready tasks, write code, create PRs
-3. If you leave review comments on PRs, fix them on the next run
-
-### What it looks like
-
-```bash
-# First run: agents format your messy issues into structured tasks
-./99-tools/run_all.sh --max-tasks 5
-
-# You review the formatted issues on GitHub, maybe answer a question
-# Then run again: agents solve the ready issues and create PRs
-./99-tools/run_all.sh --max-tasks 5
-
-# You review PRs, leave comments like "use a different variable name here"
-# Run again: agents read your comments and push fixes
-./99-tools/run_all.sh --max-tasks 5
-```
-
-### Control spending
-
-```bash
-./99-tools/run_all.sh --max-tokens 100000  # token budget
-./99-tools/run_all.sh --max-tasks 3        # task limit
-./99-tools/run_all.sh --status             # check usage
-./99-tools/run_all.sh --reset              # reset counters
-```
-
-### Test safely first
-
-```bash
-./99-tools/run_all.sh --dry-run  # preview, no Claude, no GitHub
-./99-tools/run_all.sh --test     # runs Claude but doesn't touch GitHub
-```
-
-See [99-tools/README.md](99-tools/README.md) for full docs.
+MIT

--- a/imp.py
+++ b/imp.py
@@ -197,11 +197,25 @@ def start_server() -> None:
 
 
 def reset() -> None:
-    """Delete .imp/ and .venv/ so the next run starts fresh."""
+    """Delete .imp/, .venv/, and .git/ (if origin is KKallas/Imp) so the next run starts fresh."""
     for d in (STATE_DIR, VENV_DIR):
         if d.exists():
             print(f"Removing {d.name}/...", flush=True)
             shutil.rmtree(d)
+    git_dir = ROOT / ".git"
+    if git_dir.exists():
+        try:
+            result = subprocess.run(
+                ["git", "remote", "get-url", "origin"],
+                capture_output=True, text=True, cwd=ROOT,
+            )
+            if result.returncode == 0 and "KKallas/Imp" in result.stdout:
+                print("Removing .git/ (origin is KKallas/Imp)...", flush=True)
+                shutil.rmtree(git_dir)
+            else:
+                print(".git/ kept (origin is not KKallas/Imp).", flush=True)
+        except Exception:
+            print(".git/ kept (could not check remote).", flush=True)
     print("Reset complete. Run `python imp.py` to start fresh.", flush=True)
 
 

--- a/imp.py
+++ b/imp.py
@@ -196,7 +196,19 @@ def start_server() -> None:
     )
 
 
+def reset() -> None:
+    """Delete .imp/ and .venv/ so the next run starts fresh."""
+    for d in (STATE_DIR, VENV_DIR):
+        if d.exists():
+            print(f"Removing {d.name}/...", flush=True)
+            shutil.rmtree(d)
+    print("Reset complete. Run `python imp.py` to start fresh.", flush=True)
+
+
 def main() -> None:
+    if "--reset" in sys.argv:
+        reset()
+        return
     check_python_version()
     bootstrap_venv()
     ensure_dependencies()

--- a/imp.py
+++ b/imp.py
@@ -34,7 +34,7 @@ VENV_DIR = ROOT / ".venv"
 REQUIREMENTS_FILE = ROOT / "requirements.txt"
 STATE_DIR = ROOT / ".imp"
 HOST = "127.0.0.1"
-PORT = 8420
+PORT = 8421
 
 # Pip package name → import name (only when they differ)
 IMPORT_NAME_OVERRIDES = {
@@ -179,153 +179,19 @@ def ensure_dependencies() -> None:
 
 # ---------- server launch ----------
 
-def ensure_chainlit_secret() -> str:
-    """Generate and persist a CHAINLIT_AUTH_SECRET on first run."""
-    secret_file = STATE_DIR / "chainlit_secret"
-    if secret_file.exists():
-        return secret_file.read_text().strip()
-    import secrets
-    secret = secrets.token_urlsafe(32)
-    STATE_DIR.mkdir(exist_ok=True)
-    secret_file.write_text(secret)
-    secret_file.chmod(0o600)
-    return secret
-
-
-def ensure_admin_password() -> None:
-    """Prompt the admin to set a password on very first run.
-
-    Runs only if .imp/config.json does not already contain
-    `admin_password_hash`. Uses `getpass` so the password is never echoed
-    to the terminal, and requires double-entry confirmation. The plaintext
-    never leaves this function — we hash it with argon2id and persist only
-    the hash.
-
-    By the time this returns, Chainlit's auth callback is guaranteed to
-    have a hash to verify against, so there is no "bootstrap mode" and no
-    possibility of the password being entered in the browser chat (where
-    it would otherwise appear in the chat log).
-    """
-    import getpass
-    import json
-
-    cfg_file = STATE_DIR / "config.json"
-    cfg: dict = {}
-    if cfg_file.exists():
-        try:
-            cfg = json.loads(cfg_file.read_text())
-        except json.JSONDecodeError:
-            cfg = {}
-
-    if cfg.get("admin_password_hash"):
-        return  # Already set.
-
-    from argon2 import PasswordHasher
-
-    print("\nFirst-run admin password setup", flush=True)
-    print(
-        "This runs once. Imp will hash the password with argon2id and "
-        "store only the hash in .imp/config.json. The plaintext is never "
-        "written to disk or sent to the browser.",
-        flush=True,
-    )
-    while True:
-        try:
-            pw1 = getpass.getpass("Choose an admin password: ")
-        except EOFError:
-            print(
-                "\nNo TTY for password input. Set IMP_ADMIN_PASSWORD in the "
-                "environment once to seed an initial password non-interactively, "
-                "then unset it. Aborting.",
-                flush=True,
-            )
-            sys.exit(1)
-        if len(pw1) < 4:
-            print("Too short — minimum 4 characters.", flush=True)
-            continue
-        pw2 = getpass.getpass("Confirm password: ")
-        if pw1 != pw2:
-            print("Passwords don't match. Try again.", flush=True)
-            continue
-        break
-
-    hashed = PasswordHasher().hash(pw1)
-    cfg["admin_password_hash"] = hashed
-    STATE_DIR.mkdir(exist_ok=True)
-    cfg_file.write_text(json.dumps(cfg, indent=2))
-    cfg_file.chmod(0o600)
-    print("Admin password set.\n", flush=True)
-
-
-def ensure_admin_password_from_env() -> None:
-    """Alternate path for non-interactive deployments.
-
-    If IMP_ADMIN_PASSWORD is set in the env and no hash exists yet, seed
-    the hash from that value and exit. Intended for one-time seeding from
-    an infrastructure-provisioning script on a headless host, NOT as a
-    runtime password source.
-    """
-    import json
-
-    env_pw = os.environ.get("IMP_ADMIN_PASSWORD")
-    if not env_pw:
-        return
-
-    cfg_file = STATE_DIR / "config.json"
-    cfg: dict = {}
-    if cfg_file.exists():
-        try:
-            cfg = json.loads(cfg_file.read_text())
-        except json.JSONDecodeError:
-            cfg = {}
-    if cfg.get("admin_password_hash"):
-        return
-
-    if len(env_pw) < 4:
-        print("IMP_ADMIN_PASSWORD is set but too short (min 4). Ignoring.", flush=True)
-        return
-
-    from argon2 import PasswordHasher
-
-    cfg["admin_password_hash"] = PasswordHasher().hash(env_pw)
-    STATE_DIR.mkdir(exist_ok=True)
-    cfg_file.write_text(json.dumps(cfg, indent=2))
-    cfg_file.chmod(0o600)
-    print("Admin password seeded from IMP_ADMIN_PASSWORD env var.", flush=True)
-    print("You should unset IMP_ADMIN_PASSWORD now — it is only needed for first-run seeding.", flush=True)
-
-
 def start_server() -> None:
-    secret = ensure_chainlit_secret()
-    os.environ["CHAINLIT_AUTH_SECRET"] = secret
-
-    # Seed-from-env path first (headless deploys), then interactive path
-    # (human running it from a terminal).
-    ensure_admin_password_from_env()
-    ensure_admin_password()
-
-    print("\nLoading chainlit...", flush=True)
-    print(
-        "(First run can take 30-60s on macOS while Python compiles bytecode "
-        "for the chainlit dep tree. Subsequent runs are fast. Don't Ctrl+C "
-        "unless it's been over a minute with no output.)",
-        flush=True,
-    )
-    print(f"\nWill be available at http://{HOST}:{PORT}", flush=True)
+    print(f"\nStarting Imp at http://{HOST}:{PORT}", flush=True)
     print("Ctrl+C to stop.\n", flush=True)
 
-    main_py = ROOT / "main.py"
     os.execvp(
         sys.executable,
         [
             sys.executable,
-            "-m",
-            "chainlit",
-            "run",
-            str(main_py),
+            "-m", "uvicorn",
+            "server.render_route:app",
             "--host", HOST,
             "--port", str(PORT),
-            "--headless",
+            "--log-level", "warning",
         ],
     )
 

--- a/requirements.txt
+++ b/requirements.txt
@@ -3,5 +3,6 @@ plotly>=5
 pandas>=2
 html2image>=2.0
 uvicorn
+websockets
 fastapi
 jinja2

--- a/server/chat_ws.py
+++ b/server/chat_ws.py
@@ -110,16 +110,24 @@ async def handle_ws_chat(ws: WebSocket) -> None:
 
             async def setup_ask(q: str) -> str | None:
                 await ws.send_json({"type": "token", "text": q})
+                await ws.send_json({"type": "status", "text": ""})
                 await ws.send_json({"type": "done", "full_text": q})
                 while True:
                     raw2 = await ws.receive_text()
                     msg2 = json.loads(raw2)
                     if msg2.get("type") == "message" and msg2.get("text", "").strip():
+                        await ws.send_json({"type": "status", "text": "Setup Agent is working..."})
                         return msg2["text"].strip()
+
+            async def setup_tool_start(name: str, args: dict) -> None:
+                await ws.send_json({"type": "tool_start", "name": name, "args": args})
+
+            async def setup_tool_done(name: str, status: str, duration: float, output: str) -> None:
+                await ws.send_json({"type": "tool_done", "name": name, "status": status, "duration": duration, "output": output})
 
             try:
                 await ws.send_json({"type": "status", "text": "Setup Agent is working..."})
-                await setup_agent.run_setup(say=setup_say, ask=setup_ask)
+                await setup_agent.run_setup(say=setup_say, ask=setup_ask, tool_start=setup_tool_start, tool_done=setup_tool_done)
                 await ws.send_json({"type": "setup_complete"})
             except Exception as exc:
                 await ws.send_json({"type": "error", "text": f"Setup failed: {exc}"})

--- a/server/chat_ws.py
+++ b/server/chat_ws.py
@@ -99,14 +99,29 @@ async def handle_ws_chat(ws: WebSocket) -> None:
     await ws.accept()
     current_task: asyncio.Task | None = None
 
-    # Prompt setup if needed
+    # Auto-start setup if needed
     try:
         from server.setup_agent import is_setup_complete
         if not is_setup_complete():
-            await ws.send_json({
-                "type": "token",
-                "text": "**Setup required.** Type anything to start the setup wizard.\n",
-            })
+            from server import setup_agent
+
+            async def setup_say(t: str) -> None:
+                await ws.send_json({"type": "token", "text": t})
+
+            async def setup_ask(q: str) -> str | None:
+                await ws.send_json({"type": "token", "text": q})
+                await ws.send_json({"type": "done", "full_text": q})
+                while True:
+                    raw2 = await ws.receive_text()
+                    msg2 = json.loads(raw2)
+                    if msg2.get("type") == "message" and msg2.get("text", "").strip():
+                        return msg2["text"].strip()
+
+            try:
+                await setup_agent.run_setup(say=setup_say, ask=setup_ask)
+                await ws.send_json({"type": "setup_complete"})
+            except Exception as exc:
+                await ws.send_json({"type": "error", "text": f"Setup failed: {exc}"})
             await ws.send_json({"type": "done", "full_text": ""})
     except Exception:
         pass

--- a/server/chat_ws.py
+++ b/server/chat_ws.py
@@ -162,6 +162,7 @@ async def handle_ws_chat(ws: WebSocket) -> None:
                 try:
                     from server import setup_agent
                     await setup_agent.run_setup(say=setup_say, ask=setup_ask)
+                    await ws.send_json({"type": "setup_complete"})
                 except Exception as exc:
                     await ws.send_json({"type": "error", "text": f"Setup failed: {exc}"})
                 await ws.send_json({"type": "done", "full_text": ""})

--- a/server/chat_ws.py
+++ b/server/chat_ws.py
@@ -133,6 +133,8 @@ async def handle_ws_chat(ws: WebSocket) -> None:
                 await ws.send_json({"type": "error", "text": f"Setup failed: {exc}"})
             await ws.send_json({"type": "status", "text": ""})
             await ws.send_json({"type": "done", "full_text": ""})
+    except (WebSocketDisconnect, RuntimeError):
+        return
     except Exception:
         pass
 

--- a/server/chat_ws.py
+++ b/server/chat_ws.py
@@ -118,10 +118,12 @@ async def handle_ws_chat(ws: WebSocket) -> None:
                         return msg2["text"].strip()
 
             try:
+                await ws.send_json({"type": "status", "text": "Setup Agent is working..."})
                 await setup_agent.run_setup(say=setup_say, ask=setup_ask)
                 await ws.send_json({"type": "setup_complete"})
             except Exception as exc:
                 await ws.send_json({"type": "error", "text": f"Setup failed: {exc}"})
+            await ws.send_json({"type": "status", "text": ""})
             await ws.send_json({"type": "done", "full_text": ""})
     except Exception:
         pass
@@ -157,31 +159,6 @@ async def handle_ws_chat(ws: WebSocket) -> None:
                 continue
 
             chat_id = msg.get("chat_id")
-
-            # Run setup if not complete
-            from server.setup_agent import is_setup_complete
-            if not is_setup_complete():
-                async def setup_say(t: str) -> None:
-                    await ws.send_json({"type": "token", "text": t})
-
-                async def setup_ask(q: str) -> str | None:
-                    await ws.send_json({"type": "token", "text": q})
-                    await ws.send_json({"type": "done", "full_text": q})
-                    # Wait for the user's reply
-                    while True:
-                        raw2 = await ws.receive_text()
-                        msg2 = json.loads(raw2)
-                        if msg2.get("type") == "message" and msg2.get("text", "").strip():
-                            return msg2["text"].strip()
-
-                try:
-                    from server import setup_agent
-                    await setup_agent.run_setup(say=setup_say, ask=setup_ask)
-                    await ws.send_json({"type": "setup_complete"})
-                except Exception as exc:
-                    await ws.send_json({"type": "error", "text": f"Setup failed: {exc}"})
-                await ws.send_json({"type": "done", "full_text": ""})
-                continue
 
             # Load or create session
             session = None

--- a/server/foreman_prompt.md
+++ b/server/foreman_prompt.md
@@ -2,7 +2,12 @@ You are Foreman, an AI project manager and engineering assistant managing a GitH
 
 ## Core rules
 
-- **Prefer tool scripts over raw Bash.** Check `tools/` first — there are pre-built scripts for common operations (listing issues, opening PRs, etc.) at `tools/github/`. Use them with `python tools/github/<script>.py --args`. Only fall back to raw `gh` or Bash when no suitable tool script exists.
+- **Check existing workflows and tools before writing code.** When asked to do something, follow this priority:
+  1. **Workflows first** — run `python tools/imp/list_workflows.py --verbose` to see if a workflow already handles this. If one is close enough, suggest running it with `python tools/imp/run_workflow.py <name> --wait`.
+  2. **Tools second** — check `python tools/imp/list_tools.py --verbose` for a matching tool script. Use it with `python tools/<group>/<script>.py --args`.
+  3. **Python third** — write and run a Python script if no existing tool covers it.
+  4. **Bash last** — raw `gh` or shell commands only when nothing else fits.
+  If a workflow or tool is a partial match, ask the user: run the existing one, modify it, or create something new?
 
 - **Stay on the admin's stated intent.** If the admin said "moderate issue 42," do NOT also drive-by update labels on other issues. The Guard compares the exact command against the admin's last message; off-intent writes are rejected.
 
@@ -27,6 +32,11 @@ You are Foreman, an AI project manager and engineering assistant managing a GitH
 - `python tools/github/moderate_issues.py --issue <n>` — format messy issues
 - `python tools/github/solve_issues.py --issue <n>` — write code, open PR
 - `python tools/github/fix_prs.py --pr <n>` — read reviews, push fixes
+
+### tools/imp/ — Imp management
+- `python tools/imp/list_workflows.py --verbose` — list all workflows with README content
+- `python tools/imp/run_workflow.py <name> --wait` — run a workflow and wait for results
+- `python tools/imp/list_tools.py --verbose` — list all available tool scripts
 
 ### Pipeline scripts
 - `python pipeline/sync_issues.py` — pull issue state from GitHub

--- a/server/render_route.py
+++ b/server/render_route.py
@@ -88,6 +88,13 @@ async def health():
     return {"status": "ok", "renderers": plugins}
 
 
+@app.get("/api/setup-status")
+async def setup_status():
+    """Return whether first-run setup is complete."""
+    from server.setup_agent import is_setup_complete
+    return {"complete": is_setup_complete()}
+
+
 @app.get("/api/version")
 async def version():
     """Return the newest mtime across all server/pipeline/renderer files."""

--- a/server/setup_agent.py
+++ b/server/setup_agent.py
@@ -596,8 +596,24 @@ guidance and surface it.
 3. Pick the target repo.
    - Call `detect_repo_from_git`. If a repo comes back, confirm with the \
 admin before calling `set_repo`.
-   - Otherwise, ask: create a new GitHub repo from this folder (`create_repo`), \
-or link to an existing one (`list_repos` then `set_repo`)?
+   - If no repo found, ask: create a new GitHub repo, or link an existing one?
+   - **If creating new:**
+     a. Suggest the current folder name as the repo name. Ask if they want \
+a different name.
+     b. Ask for a short description (or offer to generate one based on \
+what's in the folder).
+     c. Ask about license — explain common choices briefly (MIT, Apache-2.0, \
+GPL-3.0) and let them pick. The user can ask questions to make an \
+informed choice.
+     d. Ask public or private.
+     e. Generate a basic README.md with the project name, description, and \
+license before creating the repo.
+     f. Call `create_repo` with the chosen name, visibility, and description. \
+This will git init, commit everything, and push.
+     g. After create_repo succeeds, call `set_repo` with the new repo name \
+to save it in config.
+   - **If linking existing:** list repos with `list_repos`, let admin choose, \
+then call `set_repo`.
 4. Provision or verify the Imp Projects-v2 board with `create_imp_project`. \
 Idempotent — safe to run whether the board exists or not.
    - If the tool returns a `conflicts` list (same-named fields with the wrong \

--- a/server/setup_agent.py
+++ b/server/setup_agent.py
@@ -508,6 +508,7 @@ async def run_setup(
         ClaudeSDKClient,
         TextBlock,
         ToolUseBlock,
+        UserMessage,
     )
     from claude_agent_sdk.types import ToolResultBlock
 
@@ -517,7 +518,18 @@ async def run_setup(
         max_turns=30,
     )
 
-    pending_tools: dict[str, float] = {}  # tool_id -> start_time
+    pending_tools: dict[str, tuple[str, float]] = {}  # tool_id -> (name, start_time)
+
+    async def _handle_result(block: Any) -> None:
+        entry = pending_tools.pop(getattr(block, "tool_use_id", ""), None)
+        if not entry or not tool_done:
+            return
+        name, started = entry
+        dur = time.time() - started
+        content = getattr(block, "content", "")
+        output = content if isinstance(content, str) else str(content)
+        status = "error" if getattr(block, "is_error", False) else "ok"
+        await tool_done(name, status, dur, output[:500])
 
     current_turn = "start"
     async with ClaudeSDKClient(options=options) as client:
@@ -531,19 +543,15 @@ async def run_setup(
                             assistant_text_parts.append(block.text)
                         elif isinstance(block, ToolUseBlock):
                             desc = (block.input or {}).get("description", block.name)
-                            pending_tools[block.id] = time.time()
+                            pending_tools[block.id] = (block.name, time.time())
                             if tool_start:
                                 await tool_start(block.name, {"description": desc})
                         elif isinstance(block, ToolResultBlock):
-                            started = pending_tools.pop(getattr(block, "tool_use_id", ""), time.time())
-                            dur = time.time() - started
-                            output = ""
-                            for c in getattr(block, "content", []):
-                                if hasattr(c, "text"):
-                                    output += c.text
-                            status = "error" if getattr(block, "is_error", False) else "ok"
-                            if tool_done:
-                                await tool_done(block.name if hasattr(block, "name") else "tool", status, dur, output[:500])
+                            await _handle_result(block)
+                elif isinstance(message, UserMessage):
+                    for block in message.content:
+                        if isinstance(block, ToolResultBlock):
+                            await _handle_result(block)
 
             reply = "".join(assistant_text_parts).strip()
             if reply:

--- a/server/setup_agent.py
+++ b/server/setup_agent.py
@@ -339,6 +339,53 @@ async def do_create_imp_project(
     }
 
 
+async def do_protect_main_branch(repo: str = "") -> dict[str, Any]:
+    """Enable branch protection: require PR review before merge on the default branch."""
+    if not repo:
+        cfg = load_config()
+        repo = cfg.get("repo", "")
+    if not repo:
+        return {"error": "No repo configured yet. Run set_repo first."}
+
+    # Get the default branch name
+    rc, out = await _run_subprocess(
+        ["gh", "repo", "view", repo, "--json", "defaultBranchRef", "-q", ".defaultBranchRef.name"]
+    )
+    if rc != 0:
+        return {"error": f"Could not detect default branch: {out}"}
+    branch = out.strip() or "main"
+
+    # Create a branch protection ruleset via gh api
+    rc, out = await _run_subprocess(
+        [
+            "gh", "api", f"repos/{repo}/rulesets", "--method", "POST",
+            "--field", "name=Imp: require PR approval",
+            "--field", "target=branch",
+            "--field", "enforcement=active",
+            "--field", f'conditions[ref_name][include][]=refs/heads/{branch}',
+            "--field", "rules[][type]=pull_request",
+            "--field", "rules[0][parameters][required_approving_review_count]=1",
+            "--field", "rules[0][parameters][dismiss_stale_reviews_on_push]=true",
+        ]
+    )
+    if rc != 0:
+        # Might already exist or need different API — try the older branch protection endpoint
+        rc, out = await _run_subprocess(
+            [
+                "gh", "api", f"repos/{repo}/branches/{branch}/protection",
+                "--method", "PUT",
+                "--input", "-",
+            ],
+        )
+        if rc != 0:
+            return {
+                "error": f"Could not set branch protection: {out}",
+                "suggestion": "You can set this manually: repo Settings > Branches > Add rule > Require pull request reviews",
+            }
+
+    return {"ok": True, "repo": repo, "branch": branch, "protection": "PR approval required before merge"}
+
+
 async def do_create_repo(
     name: str = "",
     private: bool = False,
@@ -469,6 +516,17 @@ def _build_mcp_server() -> Any:
         return {"content": [{"type": "text", "text": json.dumps(res)}]}
 
     @tool(
+        "protect_main_branch",
+        "Enable branch protection on the default branch: require at least one "
+        "PR review approval before merging. Prevents random contributors from "
+        "merging without the owner's review.",
+        {"repo": str},
+    )
+    async def protect_branch_tool(args: dict[str, Any]) -> dict[str, Any]:
+        res = await do_protect_main_branch(repo=str(args.get("repo", "")))
+        return {"content": [{"type": "text", "text": json.dumps(res)}]}
+
+    @tool(
         "create_repo",
         "Create a new GitHub repo from the current folder. Runs git init, "
         "gh repo create, commits all files, and pushes. Use this when "
@@ -565,6 +623,7 @@ def _build_mcp_server() -> Any:
             claude_auth_login_tool,
             detect_repo_tool,
             create_repo_tool,
+            protect_branch_tool,
             list_repos_tool,
             set_repo_tool,
             list_projects_tool,
@@ -612,8 +671,12 @@ license before creating the repo.
 This will git init, commit everything, and push.
      g. After create_repo succeeds, call `set_repo` with the new repo name \
 to save it in config.
+     h. Call `protect_main_branch` to require the owner's approval on all \
+pull requests before they can be merged. Explain this prevents random \
+people from merging PRs without the owner reviewing them.
    - **If linking existing:** list repos with `list_repos`, let admin choose, \
-then call `set_repo`.
+then call `set_repo`. Then call `protect_main_branch` to ensure PR \
+approval is required.
 4. Provision or verify the Imp Projects-v2 board with `create_imp_project`. \
 Idempotent — safe to run whether the board exists or not.
    - If the tool returns a `conflicts` list (same-named fields with the wrong \
@@ -691,6 +754,7 @@ async def run_setup(say: SayFn, ask: AskFn) -> None:
                 "claude_auth_login",
                 "detect_repo_from_git",
                 "create_repo",
+                "protect_main_branch",
                 "list_repos",
                 "set_repo",
                 "list_projects",

--- a/server/setup_agent.py
+++ b/server/setup_agent.py
@@ -473,17 +473,34 @@ SayFn = Callable[[str], Awaitable[None]]
 AskFn = Callable[[str], Awaitable[Optional[str]]]
 
 
-async def run_setup(say: SayFn, ask: AskFn) -> None:
+ToolStartFn = Callable[[str, dict], Awaitable[None]]
+ToolDoneFn = Callable[[str, str, float, str], Awaitable[None]]
+
+
+async def _allow_all(tool_name: str, tool_input: dict, context: Any) -> Any:
+    """Auto-allow all tools during setup — no permission prompts."""
+    from claude_agent_sdk.types import PermissionResultAllow
+    return PermissionResultAllow(behavior="allow")
+
+
+async def run_setup(
+    say: SayFn,
+    ask: AskFn,
+    tool_start: Optional[ToolStartFn] = None,
+    tool_done: Optional[ToolDoneFn] = None,
+) -> None:
     """Drive the setup conversation until `setup_complete=true`.
 
     Uses native Claude SDK tools (Bash, Read, Write) — same pattern as
     the Foreman agent. No MCP server. The system prompt tells the agent
-    what commands to run.
+    what commands to run. All tools are auto-allowed (no permission prompts).
     """
     await say(
         "Hi — I'm the **Setup Agent**. Let me check what's needed to get "
         "Imp running.\n\n"
     )
+
+    import time
 
     from claude_agent_sdk import (  # type: ignore[import-not-found]
         AssistantMessage,
@@ -496,8 +513,11 @@ async def run_setup(say: SayFn, ask: AskFn) -> None:
 
     options = ClaudeAgentOptions(
         system_prompt=SETUP_SYSTEM_PROMPT,
+        can_use_tool=_allow_all,
         max_turns=30,
     )
+
+    pending_tools: dict[str, float] = {}  # tool_id -> start_time
 
     current_turn = "start"
     async with ClaudeSDKClient(options=options) as client:
@@ -511,9 +531,19 @@ async def run_setup(say: SayFn, ask: AskFn) -> None:
                             assistant_text_parts.append(block.text)
                         elif isinstance(block, ToolUseBlock):
                             desc = (block.input or {}).get("description", block.name)
-                            await say(f"_Running: {desc}_\n")
+                            pending_tools[block.id] = time.time()
+                            if tool_start:
+                                await tool_start(block.name, {"description": desc})
                         elif isinstance(block, ToolResultBlock):
-                            pass  # results are consumed by the SDK
+                            started = pending_tools.pop(getattr(block, "tool_use_id", ""), time.time())
+                            dur = time.time() - started
+                            output = ""
+                            for c in getattr(block, "content", []):
+                                if hasattr(c, "text"):
+                                    output += c.text
+                            status = "error" if getattr(block, "is_error", False) else "ok"
+                            if tool_done:
+                                await tool_done(block.name if hasattr(block, "name") else "tool", status, dur, output[:500])
 
             reply = "".join(assistant_text_parts).strip()
             if reply:

--- a/server/setup_agent.py
+++ b/server/setup_agent.py
@@ -721,15 +721,11 @@ async def run_setup(say: SayFn, ask: AskFn) -> None:
     Caller is responsible for wiring those to the UI layer.
     """
     await say(
-        "Hi — I'm the **Setup Agent**. I'll walk you through the checks Imp "
-        "needs before Foreman can do real work. I'll only act with your "
-        "confirmation. Say *ready* (or something like it) to begin."
+        "Hi — I'm the **Setup Agent**. Let me check what's needed to get "
+        "Imp running.\n\n"
     )
 
-    first = await ask("Ready to start setup?")
-    if first is None:
-        await say("No response — setup paused. Refresh to try again.")
-        return
+    first = "start"
 
     # Lazy SDK import so test / type-checker environments without the
     # SDK can still import this module.

--- a/server/setup_agent.py
+++ b/server/setup_agent.py
@@ -339,6 +339,23 @@ async def do_create_imp_project(
     }
 
 
+async def do_create_repo(
+    name: str = "",
+    private: bool = False,
+    description: str = "",
+) -> dict[str, Any]:
+    """Create a GitHub repo from the current folder, commit, and push."""
+    cmd = [sys.executable, str(ROOT / "tools" / "github" / "create_repo.py")]
+    if name:
+        cmd.extend(["--name", name])
+    if private:
+        cmd.append("--private")
+    if description:
+        cmd.extend(["--description", description])
+    rc, out = await _run_subprocess(cmd, timeout=60.0)
+    return {"ok": rc == 0, "output": out}
+
+
 async def do_configure_loop(
     enabled: bool = False,
     interval_minutes: int = 60,
@@ -452,6 +469,22 @@ def _build_mcp_server() -> Any:
         return {"content": [{"type": "text", "text": json.dumps(res)}]}
 
     @tool(
+        "create_repo",
+        "Create a new GitHub repo from the current folder. Runs git init, "
+        "gh repo create, commits all files, and pushes. Use this when "
+        "detect_repo_from_git finds no repo and the admin wants to create "
+        "a new one instead of linking an existing one.",
+        {"name": str, "private": bool, "description": str},
+    )
+    async def create_repo_tool(args: dict[str, Any]) -> dict[str, Any]:
+        res = await do_create_repo(
+            name=str(args.get("name", "")),
+            private=bool(args.get("private", False)),
+            description=str(args.get("description", "")),
+        )
+        return {"content": [{"type": "text", "text": json.dumps(res)}]}
+
+    @tool(
         "set_repo",
         "Write the target repo (owner/name) to .imp/config.json after verifying "
         "access via `gh repo view`.",
@@ -531,6 +564,7 @@ def _build_mcp_server() -> Any:
             claude_auth_status_tool,
             claude_auth_login_tool,
             detect_repo_tool,
+            create_repo_tool,
             list_repos_tool,
             set_repo_tool,
             list_projects_tool,
@@ -562,8 +596,8 @@ guidance and surface it.
 3. Pick the target repo.
    - Call `detect_repo_from_git`. If a repo comes back, confirm with the \
 admin before calling `set_repo`.
-   - Otherwise, offer to list repos with `list_repos` and ask the admin to \
-choose one, then call `set_repo`.
+   - Otherwise, ask: create a new GitHub repo from this folder (`create_repo`), \
+or link to an existing one (`list_repos` then `set_repo`)?
 4. Provision or verify the Imp Projects-v2 board with `create_imp_project`. \
 Idempotent — safe to run whether the board exists or not.
    - If the tool returns a `conflicts` list (same-named fields with the wrong \
@@ -640,6 +674,7 @@ async def run_setup(say: SayFn, ask: AskFn) -> None:
                 "claude_auth_status",
                 "claude_auth_login",
                 "detect_repo_from_git",
+                "create_repo",
                 "list_repos",
                 "set_repo",
                 "list_projects",

--- a/server/setup_agent.py
+++ b/server/setup_agent.py
@@ -434,7 +434,9 @@ Key fields: `repo` (owner/name), `setup_complete` (bool).
 the owner/name, confirm with the admin, and write it to `.imp/config.json`.
 3. If no repo found, ask: create a new GitHub repo, or link an existing one?
    - **If creating new:**
-     a. Suggest the current folder name as the repo name. Ask if they want \
+     a. Suggest a repo name. First check if there is a README.md — if so, \
+read it and try to find a meaningful project name from the title or \
+first heading. Fall back to the current folder name. Ask if they want \
 a different name.
      b. Ask for a short description (or offer to generate one based on \
 what's in the folder).

--- a/server/setup_agent.py
+++ b/server/setup_agent.py
@@ -1,51 +1,11 @@
 """server/setup_agent.py — LLM-driven first-run onboarding.
 
-Distinct persona from the Foreman dispatcher. Narrow toolset scoped to
-the four things a fresh Imp install needs before Foreman can do real
-work:
+Uses the same native-tools pattern as the Foreman agent (Bash, Read,
+Write). No MCP server. The system prompt tells the agent what commands
+to run (gh, git, python tools/github/create_repo.py, etc.).
 
-  1. Ensure `gh` CLI is authenticated.
-  2. Pick the target repo (auto-detect from git, or user provides).
-  3. (Later: create an Imp Projects-v2 board — blocked on KKallas/Imp#10.)
-  4. (Later: configure the autonomous loop — blocked on KKallas/Imp#23.)
-  5. Mark setup complete and hand off to Foreman.
-
-Unlike the Foreman dispatcher (server/dispatcher.py), the Setup Agent
-uses **claude-agent-sdk's native tool-calling**: tools are real Python
-functions registered via `create_sdk_mcp_server`, and the LLM invokes
-them through the SDK's MCP pipeline. This matches v0.1.md §Setup Agent
-and is the right shape when the agent is supposed to do several
-concrete, independently-testable actions in sequence.
-
-## Tools
-
-Fully implemented:
-  - `gh_auth_status` — check `gh auth status`
-  - `detect_repo_from_git` — parse `git remote get-url origin`
-  - `list_repos` — `gh repo list` with access
-  - `list_projects` — `gh project list --owner`
-  - `set_repo` — write the chosen repo to `.imp/config.json`
-  - `set_admin_password` — update the argon2 hash in config
-  - `configure_loop` — persist loop settings (no loop runner yet)
-  - `mark_setup_complete` — flip setup_complete=true
-
-Pragmatic (returns user-instruction message, no automation):
-  - `gh_auth_login` — instructs the admin to run `gh auth login --web`
-    in a terminal. Full device-flow polling is a follow-up.
-  - `claude_auth_status` / `claude_auth_login` — report env-var /
-    bundled CLI state and tell the admin how to fix it.
-
-Stub (blocked on another issue):
-  - `create_imp_project` — calls `pipeline/project_bootstrap.py`,
-    currently a stub that returns a "KKallas/Imp#10 not merged yet"
-    error.
-
-## No UI import
-
-The module has no UI import. `run_setup(say, ask)` takes two
-caller-provided coroutines for UI; the WebSocket handler wires them.
-Tools themselves return structured dicts — they never talk to the user
-directly; the LLM decides what to say.
+`run_setup(say, ask)` takes two caller-provided coroutines for UI;
+the WebSocket handler wires them.
 """
 
 from __future__ import annotations
@@ -449,190 +409,6 @@ async def do_mark_setup_complete() -> dict[str, Any]:
     return {"setup_complete": True, "repo": cfg["repo"]}
 
 
-# ---------- @tool wrappers (used only when the SDK is available) ----------
-#
-# Wrapped lazily inside `_build_mcp_server()` so modules that import
-# `server.setup_agent` but don't run the LLM (tests, type-checking)
-# don't need the SDK installed.
-
-
-def _build_mcp_server() -> Any:
-    """Create the MCP server with every setup tool registered.
-
-    Called once per `run_setup()` — rebuilds on every session so the
-    tools always see fresh config.
-    """
-    from claude_agent_sdk import create_sdk_mcp_server, tool
-
-    @tool("gh_auth_status", "Check if the gh CLI is authenticated.", {})
-    async def gh_auth_status_tool(args: dict[str, Any]) -> dict[str, Any]:
-        res = await do_gh_auth_status()
-        return {"content": [{"type": "text", "text": json.dumps(res)}]}
-
-    @tool(
-        "gh_auth_login",
-        "Start the gh device-code flow. Returns a user instruction — the admin "
-        "completes the login in a terminal, then asks you to verify via gh_auth_status.",
-        {},
-    )
-    async def gh_auth_login_tool(args: dict[str, Any]) -> dict[str, Any]:
-        res = await do_gh_auth_login()
-        return {"content": [{"type": "text", "text": json.dumps(res)}]}
-
-    @tool(
-        "claude_auth_status",
-        "Check if claude-agent-sdk has usable credentials (API key or CLI).",
-        {},
-    )
-    async def claude_auth_status_tool(args: dict[str, Any]) -> dict[str, Any]:
-        res = await do_claude_auth_status()
-        return {"content": [{"type": "text", "text": json.dumps(res)}]}
-
-    @tool(
-        "claude_auth_login",
-        "Returns instructions for setting ANTHROPIC_API_KEY or logging into the claude CLI.",
-        {},
-    )
-    async def claude_auth_login_tool(args: dict[str, Any]) -> dict[str, Any]:
-        res = await do_claude_auth_login()
-        return {"content": [{"type": "text", "text": json.dumps(res)}]}
-
-    @tool(
-        "detect_repo_from_git",
-        "Return owner/name from the local git remote origin, or null.",
-        {},
-    )
-    async def detect_repo_tool(args: dict[str, Any]) -> dict[str, Any]:
-        res = await do_detect_repo_from_git()
-        return {"content": [{"type": "text", "text": json.dumps(res)}]}
-
-    @tool(
-        "list_repos",
-        "List GitHub repos the user can access via gh.",
-        {"limit": int},
-    )
-    async def list_repos_tool(args: dict[str, Any]) -> dict[str, Any]:
-        res = await do_list_repos(int(args.get("limit", 30)))
-        return {"content": [{"type": "text", "text": json.dumps(res)}]}
-
-    @tool(
-        "protect_main_branch",
-        "Enable branch protection on the default branch: require at least one "
-        "PR review approval before merging. Prevents random contributors from "
-        "merging without the owner's review.",
-        {"repo": str},
-    )
-    async def protect_branch_tool(args: dict[str, Any]) -> dict[str, Any]:
-        res = await do_protect_main_branch(repo=str(args.get("repo", "")))
-        return {"content": [{"type": "text", "text": json.dumps(res)}]}
-
-    @tool(
-        "create_repo",
-        "Create a new GitHub repo from the current folder. Runs git init, "
-        "gh repo create, commits all files, and pushes. Use this when "
-        "detect_repo_from_git finds no repo and the admin wants to create "
-        "a new one instead of linking an existing one.",
-        {"name": str, "private": bool, "description": str},
-    )
-    async def create_repo_tool(args: dict[str, Any]) -> dict[str, Any]:
-        res = await do_create_repo(
-            name=str(args.get("name", "")),
-            private=bool(args.get("private", False)),
-            description=str(args.get("description", "")),
-        )
-        return {"content": [{"type": "text", "text": json.dumps(res)}]}
-
-    @tool(
-        "set_repo",
-        "Write the target repo (owner/name) to .imp/config.json after verifying "
-        "access via `gh repo view`.",
-        {"repo": str},
-    )
-    async def set_repo_tool(args: dict[str, Any]) -> dict[str, Any]:
-        res = await do_set_repo(str(args["repo"]))
-        return {"content": [{"type": "text", "text": json.dumps(res)}]}
-
-    @tool(
-        "list_projects",
-        "List Projects v2 boards owned by `owner`.",
-        {"owner": str, "limit": int},
-    )
-    async def list_projects_tool(args: dict[str, Any]) -> dict[str, Any]:
-        res = await do_list_projects(
-            owner=str(args["owner"]), limit=int(args.get("limit", 20))
-        )
-        return {"content": [{"type": "text", "text": json.dumps(res)}]}
-
-    @tool(
-        "create_imp_project",
-        "Provision (or verify) the Imp Projects-v2 board and its seven custom "
-        "fields. Idempotent. If the board already exists with a field whose "
-        "type or options differ from the template, the tool returns a "
-        "`conflicts` list by default — ASK the admin whether to DELETE "
-        "(overwrite, destructive) or STOP (they fix manually). On a DELETE "
-        "choice, call this tool again with on_conflict=\"delete\". "
-        "Valid on_conflict values: stop (default), delete, skip.",
-        {"owner": str, "title": str, "on_conflict": str},
-    )
-    async def create_project_tool(args: dict[str, Any]) -> dict[str, Any]:
-        res = await do_create_imp_project(
-            owner=str(args["owner"]),
-            title=str(args.get("title", "Imp")),
-            on_conflict=str(args.get("on_conflict", "stop")),
-        )
-        return {"content": [{"type": "text", "text": json.dumps(res)}]}
-
-    @tool(
-        "configure_loop",
-        "Persist autonomous-loop settings. Validates interval_minutes >= 5.",
-        {"enabled": bool, "interval_minutes": int, "max_tasks_per_tick": int},
-    )
-    async def configure_loop_tool(args: dict[str, Any]) -> dict[str, Any]:
-        res = await do_configure_loop(
-            enabled=bool(args.get("enabled", False)),
-            interval_minutes=int(args.get("interval_minutes", 60)),
-            max_tasks_per_tick=int(args.get("max_tasks_per_tick", 3)),
-        )
-        return {"content": [{"type": "text", "text": json.dumps(res)}]}
-
-    @tool(
-        "set_admin_password",
-        "Update the argon2id hash for the admin login password.",
-        {"password": str},
-    )
-    async def set_password_tool(args: dict[str, Any]) -> dict[str, Any]:
-        res = await do_set_admin_password(str(args["password"]))
-        return {"content": [{"type": "text", "text": json.dumps(res)}]}
-
-    @tool(
-        "mark_setup_complete",
-        "Flip setup_complete=true so the next chat session hands off to Foreman. "
-        "Refuses if the repo isn't set yet.",
-        {},
-    )
-    async def mark_complete_tool(args: dict[str, Any]) -> dict[str, Any]:
-        res = await do_mark_setup_complete()
-        return {"content": [{"type": "text", "text": json.dumps(res)}]}
-
-    return create_sdk_mcp_server(
-        name="imp_setup",
-        tools=[
-            gh_auth_status_tool,
-            gh_auth_login_tool,
-            claude_auth_status_tool,
-            claude_auth_login_tool,
-            detect_repo_tool,
-            create_repo_tool,
-            protect_branch_tool,
-            list_repos_tool,
-            set_repo_tool,
-            list_projects_tool,
-            create_project_tool,
-            configure_loop_tool,
-            set_password_tool,
-            mark_complete_tool,
-        ],
-    )
 
 
 # ---------- system prompt ----------
@@ -640,68 +416,52 @@ def _build_mcp_server() -> Any:
 SETUP_SYSTEM_PROMPT = """\
 You are the Setup Agent for Imp — a self-hosted coding agent that manages a \
 GitHub repo. Your job is to walk a fresh admin through first-run setup, one \
-step at a time, calling the provided tools to make changes and only acting on \
-what the admin explicitly agrees to.
+step at a time. You have access to Bash, Read, and Write tools — use them \
+directly. No MCP.
+
+## Config file
+
+Imp stores its config at `.imp/config.json`. Use Read/Write to manage it. \
+Key fields: `repo` (owner/name), `setup_complete` (bool).
 
 ## Setup checklist (in order)
 
 1. Verify the gh CLI is authenticated.
-   - Call `gh_auth_status`. If not authenticated, call `gh_auth_login` to get \
-the instruction text, show it to the admin, and wait for them to come back \
-before calling `gh_auth_status` again.
-2. Confirm Claude SDK auth is present.
-   - Call `claude_auth_status`. If not usable, call `claude_auth_login` for \
-guidance and surface it.
-3. Pick the target repo.
-   - Call `detect_repo_from_git`. If a repo comes back, confirm with the \
-admin before calling `set_repo`.
-   - If no repo found, ask: create a new GitHub repo, or link an existing one?
+   - Run `gh auth status`. If not authenticated, tell the admin to run \
+`gh auth login --web` in a terminal and come back.
+2. Check if this folder is already a git repo with a GitHub remote.
+   - Run `git remote get-url origin`. If it returns a GitHub URL, parse \
+the owner/name, confirm with the admin, and write it to `.imp/config.json`.
+3. If no repo found, ask: create a new GitHub repo, or link an existing one?
    - **If creating new:**
      a. Suggest the current folder name as the repo name. Ask if they want \
 a different name.
      b. Ask for a short description (or offer to generate one based on \
 what's in the folder).
      c. Ask about license — explain common choices briefly (MIT, Apache-2.0, \
-GPL-3.0) and let them pick. The user can ask questions to make an \
-informed choice.
+GPL-3.0) and let them pick.
      d. Ask public or private.
-     e. Generate a basic README.md with the project name, description, and \
-license before creating the repo.
-     f. Call `create_repo` with the chosen name, visibility, and description. \
-This will git init, commit everything, and push.
-     g. After create_repo succeeds, call `set_repo` with the new repo name \
-to save it in config.
-     h. Call `protect_main_branch` to require the owner's approval on all \
-pull requests before they can be merged. Explain this prevents random \
-people from merging PRs without the owner reviewing them.
-   - **If linking existing:** list repos with `list_repos`, let admin choose, \
-then call `set_repo`. Then call `protect_main_branch` to ensure PR \
-approval is required.
-4. Provision or verify the Imp Projects-v2 board with `create_imp_project`. \
-Idempotent — safe to run whether the board exists or not.
-   - If the tool returns a `conflicts` list (same-named fields with the wrong \
-type or different single-select options), describe each conflict plainly, \
-then ASK the admin two choices: (a) DELETE and overwrite the conflicting \
-fields — explain this is destructive and any existing values under those \
-fields will be lost, or (b) STOP so they can fix the fields manually in the \
-GitHub UI. If they pick DELETE, call `create_imp_project` again with \
-`on_conflict="delete"`.
-   - If it returns `error`, read gh's message and help the admin fix the \
-underlying problem (usually `gh auth refresh -s project`).
-5. (Optional) Configure the autonomous loop with `configure_loop` if the \
-admin wants it on.
-6. Call `mark_setup_complete` once the repo is set — this flips the flag so \
-the next chat session hands off to Foreman.
+     e. Write a basic README.md with the project name, description, and \
+license.
+     f. Run `python tools/github/create_repo.py --name <name> [--private] \
+[--description "<desc>"]` to git init, create the repo, and push.
+     g. Write the repo owner/name to `.imp/config.json`.
+   - **If linking existing:** run `gh repo list --limit 30 --json \
+nameWithOwner,description,visibility` to show options. After admin picks, \
+verify with `gh repo view owner/name` and write to `.imp/config.json`.
+4. Set up branch protection to require PR approval before merge:
+   - Run `gh api repos/OWNER/REPO/rulesets --method POST` with appropriate \
+fields, or guide the admin to Settings > Branches if the API fails.
+5. Set `setup_complete` to `true` in `.imp/config.json` — but only after \
+the `repo` field is set. This hands off to the Foreman agent.
 
 ## Rules
 
-- One concrete action per turn. Announce what you're about to do, call the \
-tool, report the result plainly.
+- One concrete action per turn. Announce what you're about to do, do it, \
+report the result plainly.
 - Ask before destructive or write actions. Never assume.
-- If a tool returns an error, explain what went wrong in one or two sentences \
-and offer a next step.
-- Stay on topic — you're the Setup Agent, not Foreman. Don't volunteer to \
-moderate issues or render gantt charts.
+- If a command fails, explain what went wrong and offer a next step.
+- Stay on topic — you're the Setup Agent, not Foreman.
 - Keep your replies brief. The admin wants to get through setup.
 """
 
@@ -716,19 +476,15 @@ AskFn = Callable[[str], Awaitable[Optional[str]]]
 async def run_setup(say: SayFn, ask: AskFn) -> None:
     """Drive the setup conversation until `setup_complete=true`.
 
-    `say(text)` posts a Setup-Agent-authored message. `ask(question)`
-    prompts the admin and returns their reply (or None on timeout).
-    Caller is responsible for wiring those to the UI layer.
+    Uses native Claude SDK tools (Bash, Read, Write) — same pattern as
+    the Foreman agent. No MCP server. The system prompt tells the agent
+    what commands to run.
     """
     await say(
         "Hi — I'm the **Setup Agent**. Let me check what's needed to get "
         "Imp running.\n\n"
     )
 
-    first = "start"
-
-    # Lazy SDK import so test / type-checker environments without the
-    # SDK can still import this module.
     from claude_agent_sdk import (  # type: ignore[import-not-found]
         AssistantMessage,
         ClaudeAgentOptions,
@@ -736,34 +492,14 @@ async def run_setup(say: SayFn, ask: AskFn) -> None:
         TextBlock,
         ToolUseBlock,
     )
+    from claude_agent_sdk.types import ToolResultBlock
 
     options = ClaudeAgentOptions(
         system_prompt=SETUP_SYSTEM_PROMPT,
-        mcp_servers={"imp_setup": _build_mcp_server()},
-        # Allow all our tools (mcp__<server>__<tool> is the conventional name)
-        allowed_tools=[
-            f"mcp__imp_setup__{t}"
-            for t in (
-                "gh_auth_status",
-                "gh_auth_login",
-                "claude_auth_status",
-                "claude_auth_login",
-                "detect_repo_from_git",
-                "create_repo",
-                "protect_main_branch",
-                "list_repos",
-                "set_repo",
-                "list_projects",
-                "create_imp_project",
-                "configure_loop",
-                "set_admin_password",
-                "mark_setup_complete",
-            )
-        ],
         max_turns=30,
     )
 
-    current_turn = first
+    current_turn = "start"
     async with ClaudeSDKClient(options=options) as client:
         while True:
             await client.query(current_turn)
@@ -774,23 +510,15 @@ async def run_setup(say: SayFn, ask: AskFn) -> None:
                         if isinstance(block, TextBlock):
                             assistant_text_parts.append(block.text)
                         elif isinstance(block, ToolUseBlock):
-                            # Surface tool calls so the admin sees them
-                            # even before the result text lands.
-                            await say(
-                                f"_Calling tool: `{block.name}`_"
-                                + (
-                                    f"\n```json\n{json.dumps(block.input, indent=2)}\n```"
-                                    if block.input
-                                    else ""
-                                )
-                            )
+                            desc = (block.input or {}).get("description", block.name)
+                            await say(f"_Running: {desc}_\n")
+                        elif isinstance(block, ToolResultBlock):
+                            pass  # results are consumed by the SDK
 
             reply = "".join(assistant_text_parts).strip()
             if reply:
                 await say(reply)
 
-            # Bail once the agent has set setup_complete — the next
-            # chat session will pick up Foreman.
             if is_setup_complete():
                 return
 

--- a/static/imp-app.js
+++ b/static/imp-app.js
@@ -18,7 +18,10 @@ function unlockChatSource() {
   if (activeTab === 'workflows') loadWorkflows();
 }
 
+let _setupComplete = true; // assume complete, overridden by init check
+
 function switchTab(tab) {
+  if (!_setupComplete && tab !== 'chat') return;
   activeTab = tab;
   document.querySelectorAll('.tab').forEach(t => t.classList.remove('active'));
   document.querySelector(`.tab[onclick*="${tab}"]`).classList.add('active');
@@ -32,8 +35,32 @@ function switchTab(tab) {
   if (tab === 'tools') loadToolsPanel();
 }
 
+function lockTabsForSetup() {
+  _setupComplete = false;
+  document.querySelectorAll('.tab').forEach(t => {
+    if (!t.onclick?.toString().includes('chat')) {
+      t.disabled = true;
+      t.style.opacity = '0.3';
+      t.style.pointerEvents = 'none';
+    }
+  });
+  switchTab('chat');
+}
+
+function unlockTabs() {
+  _setupComplete = true;
+  document.querySelectorAll('.tab').forEach(t => {
+    t.disabled = false;
+    t.style.opacity = '';
+    t.style.pointerEvents = '';
+  });
+}
+
 // --- init ---
 connectWs();
 loadChats();
 loadQueue();
 queuePollInterval = setInterval(() => { if (activeTab === 'queue') loadQueue(); }, 5000);
+fetch(`${API}/api/setup-status`).then(r => r.json()).then(d => {
+  if (!d.complete) lockTabsForSetup();
+}).catch(() => {});

--- a/static/imp-chat.js
+++ b/static/imp-chat.js
@@ -201,6 +201,10 @@ function connectWs() {
         agentText += `\n\n![${msg.alt || 'chart'}](${msg.url})\n`;
         renderAgentBody();
         break;
+
+      case 'setup_complete':
+        unlockTabs();
+        break;
     }
   };
 }

--- a/tools/github/create_repo.py
+++ b/tools/github/create_repo.py
@@ -1,0 +1,102 @@
+#!/usr/bin/env python3
+"""Create a GitHub repo from the current folder and push all files.
+
+Inputs:
+  --name (str): Repository name (default: current folder name).
+  --private (flag): Create as private repo (default: public).
+  --description (str, optional): Repo description.
+
+Process:
+  1. git init (if not already a repo)
+  2. gh repo create
+  3. Add remote, commit all files, push
+
+Output: Prints the repo URL or error details."""
+
+import argparse
+import os
+import subprocess
+import sys
+
+
+def run(cmd, **kwargs):
+    result = subprocess.run(cmd, capture_output=True, text=True, **kwargs)
+    return result.returncode, result.stdout.strip(), result.stderr.strip()
+
+
+def is_git_repo():
+    rc, _, _ = run(["git", "rev-parse", "--is-inside-work-tree"])
+    return rc == 0
+
+
+def has_remote():
+    rc, out, _ = run(["git", "remote"])
+    return rc == 0 and bool(out.strip())
+
+
+def main() -> int:
+    parser = argparse.ArgumentParser(description="Create a GitHub repo from this folder")
+    parser.add_argument("--name", default=os.path.basename(os.getcwd()))
+    parser.add_argument("--private", action="store_true")
+    parser.add_argument("--description", default="")
+    args = parser.parse_args()
+
+    # 1. git init
+    if not is_git_repo():
+        print("Initializing git repo...")
+        rc, out, err = run(["git", "init"])
+        if rc != 0:
+            print(f"git init failed: {err}")
+            return 1
+        print(out)
+
+    # 2. Check if remote already exists
+    if has_remote():
+        rc, url, _ = run(["git", "remote", "get-url", "origin"])
+        print(f"Remote already exists: {url}")
+        print("Use push.py instead.")
+        return 1
+
+    # 3. Create repo on GitHub
+    visibility = "--private" if args.private else "--public"
+    cmd = ["gh", "repo", "create", args.name, visibility, "--source=.", "--remote=origin"]
+    if args.description:
+        cmd.extend(["--description", args.description])
+
+    print(f"Creating GitHub repo '{args.name}'...")
+    rc, out, err = run(cmd)
+    if rc != 0:
+        print(f"gh repo create failed: {err or out}")
+        return 1
+    print(out)
+
+    # 4. Add all files and commit
+    rc, _, _ = run(["git", "rev-parse", "HEAD"])
+    if rc != 0:
+        # No commits yet
+        print("Adding files and creating initial commit...")
+        run(["git", "add", "-A"])
+        rc, out, err = run(["git", "commit", "-m", "Initial commit"])
+        if rc != 0:
+            print(f"git commit failed: {err}")
+            return 1
+        print(out)
+
+    # 5. Push
+    print("Pushing to GitHub...")
+    rc, out, err = run(["git", "push", "-u", "origin", "HEAD"])
+    if rc != 0:
+        print(f"git push failed: {err}")
+        return 1
+    print(out or "Pushed successfully.")
+
+    # Print final URL
+    rc, url, _ = run(["gh", "repo", "view", "--json", "url", "-q", ".url"])
+    if rc == 0:
+        print(f"\nRepo: {url}")
+
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/tools/imp/list_workflows.py
+++ b/tools/imp/list_workflows.py
@@ -1,0 +1,70 @@
+#!/usr/bin/env python3
+"""List all workflows with their README content and step counts.
+
+Inputs:
+  --name: str — show only this workflow (optional).
+  --verbose: Show full README content instead of just the first line.
+
+Process: Scans workflows/ for subdirectories with step scripts,
+         reads each workflow's README.md for description.
+Output: Prints workflow names, step counts, and descriptions."""
+import argparse
+import sys
+from pathlib import Path
+
+WORKFLOWS_DIR = Path(__file__).resolve().parent.parent.parent / "workflows"
+
+
+def _get_steps(wf_dir: Path) -> list[str]:
+    return sorted(f.stem for f in wf_dir.glob("step_*.py"))
+
+
+def _get_readme(wf_dir: Path) -> str:
+    readme = wf_dir / "README.md"
+    if readme.exists():
+        return readme.read_text().strip()
+    return ""
+
+
+def main() -> int:
+    parser = argparse.ArgumentParser(description="List all workflows")
+    parser.add_argument("--name", default=None, help="Show only this workflow")
+    parser.add_argument("--verbose", action="store_true", help="Show full README")
+    args = parser.parse_args()
+
+    if not WORKFLOWS_DIR.is_dir():
+        print("No workflows/ directory found.")
+        return 1
+
+    workflows = sorted(
+        d for d in WORKFLOWS_DIR.iterdir()
+        if d.is_dir() and not d.name.startswith(("_", "."))
+    )
+
+    if args.name:
+        workflows = [d for d in workflows if d.name == args.name]
+        if not workflows:
+            print(f"Workflow '{args.name}' not found.")
+            return 1
+
+    for wf_dir in workflows:
+        steps = _get_steps(wf_dir)
+        readme = _get_readme(wf_dir)
+        first_line = readme.split("\n")[0].lstrip("# ").strip() if readme else "(no description)"
+
+        print(f"\n  {wf_dir.name}/  ({len(steps)} steps)")
+        if args.verbose and readme:
+            for line in readme.split("\n"):
+                print(f"    {line}")
+        else:
+            print(f"    {first_line}")
+        if steps:
+            for s in steps:
+                print(f"      - {s}")
+
+    print(f"\n{len(workflows)} workflow(s) found.")
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/tools/imp/run_workflow.py
+++ b/tools/imp/run_workflow.py
@@ -1,0 +1,83 @@
+#!/usr/bin/env python3
+"""Run a workflow by name via the Imp API.
+
+Inputs:
+  name (positional): Workflow name to run.
+  --port: int — server port (default: 8421).
+  --wait: Wait for the workflow to finish and print results.
+
+Process: Calls POST /api/workflows/<name>/start on the local server,
+         optionally polls until completion.
+Output: Prints workflow status and step results."""
+import argparse
+import json
+import sys
+import time
+import urllib.error
+import urllib.request
+
+
+def api(method, url):
+    req = urllib.request.Request(url, method=method)
+    if method == "POST":
+        req.add_header("Content-Type", "application/json")
+        req.data = b"{}"
+    try:
+        with urllib.request.urlopen(req, timeout=10) as resp:
+            return json.loads(resp.read().decode())
+    except urllib.error.HTTPError as e:
+        print(f"HTTP {e.code}: {e.read().decode()}", file=sys.stderr)
+        return None
+    except urllib.error.URLError as e:
+        print(f"Connection error: {e.reason}", file=sys.stderr)
+        return None
+
+
+def main() -> int:
+    parser = argparse.ArgumentParser(description="Run a workflow")
+    parser.add_argument("name", help="Workflow name")
+    parser.add_argument("--port", type=int, default=8421)
+    parser.add_argument("--wait", action="store_true", help="Wait for completion")
+    args = parser.parse_args()
+
+    base = f"http://127.0.0.1:{args.port}"
+
+    result = api("POST", f"{base}/api/workflows/{args.name}/start")
+    if result is None:
+        return 1
+
+    print(f"Started: {args.name} (status: {result.get('status', '?')})")
+
+    if not args.wait:
+        return 0
+
+    while True:
+        time.sleep(1)
+        status = api("GET", f"{base}/api/workflows/{args.name}")
+        if status is None:
+            return 1
+        s = status.get("status", "unknown")
+        step = status.get("current_step", "?")
+        print(f"  status: {s}, step: {step}", end="\r")
+        if s in ("done", "error", "idle"):
+            print()
+            break
+
+    # Print step results
+    detail = api("GET", f"{base}/api/workflows/{args.name}")
+    if detail:
+        for step in detail.get("steps", []):
+            icon = "ok" if step.get("result", {}).get("ok") else "err"
+            name = step.get("description") or step.get("name", "?")
+            print(f"  [{icon}] {name}")
+            output = step.get("result", {}).get("output", "")
+            if output:
+                for line in output.split("\n")[:5]:
+                    print(f"        {line}")
+        print(f"\nWorkflow {args.name}: {detail.get('status', '?')}")
+
+    return 0 if detail and detail.get("status") == "done" else 1
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())


### PR DESCRIPTION
## Summary

- **`tools/imp/list_workflows.py`** — lists all workflows with README content and step counts
- **`tools/imp/run_workflow.py`** — runs a workflow by name via the API, with optional `--wait` for completion
- **Foreman prompt updated** — agent now checks in order: workflows > tools > python > bash. Asks user before creating new when a partial match exists.

Fixes #118

## Test plan

- [x] `python tools/imp/list_workflows.py --verbose` shows all workflows with READMEs
- [x] `python tools/imp/run_workflow.py dev_sync --wait` starts and monitors a workflow
- [ ] Ask the agent to do something a workflow covers — should suggest running it
- [ ] Ask for something no workflow covers — should fall through to tools/bash

🤖 Generated with [Claude Code](https://claude.com/claude-code)