### PR TITLE
Cache prompt at startup + preserve thinking/tool order

### DIFF
--- a/server/chat_history.py
+++ b/server/chat_history.py
@@ -76,6 +76,7 @@ class Turn:
     tool_calls: list[dict[str, Any]] = field(default_factory=list)
     thinking: list[str] = field(default_factory=list)
     artifacts: list[dict[str, Any]] = field(default_factory=list)
+    blocks: list[dict[str, Any]] = field(default_factory=list)
 
     def to_dict(self) -> dict[str, Any]:
         d: dict[str, Any] = {
@@ -89,6 +90,8 @@ class Turn:
             d["thinking"] = list(self.thinking)
         if self.artifacts:
             d["artifacts"] = list(self.artifacts)
+        if self.blocks:
+            d["blocks"] = list(self.blocks)
         return d
 
     @classmethod
@@ -100,6 +103,7 @@ class Turn:
             tool_calls=list(data.get("tool_calls") or []),
             thinking=list(data.get("thinking") or []),
             artifacts=list(data.get("artifacts") or []),
+            blocks=list(data.get("blocks") or []),
         )
 
 
@@ -173,6 +177,7 @@ class ChatSession:
         tool_calls: Optional[list[dict[str, Any]]] = None,
         thinking: Optional[list[str]] = None,
         artifacts: Optional[list[dict[str, Any]]] = None,
+        blocks: Optional[list[dict[str, Any]]] = None,
     ) -> Turn:
         turn = Turn(
             role=role,
@@ -180,6 +185,7 @@ class ChatSession:
             tool_calls=list(tool_calls or []),
             thinking=list(thinking or []),
             artifacts=list(artifacts or []),
+            blocks=list(blocks or []),
         )
         self.turns.append(turn)
         self.last_active_at = turn.timestamp

--- a/server/chat_ws.py
+++ b/server/chat_ws.py
@@ -33,6 +33,7 @@ class WebSocketTurnUI(TurnUI):
         self.thinking_log: list[str] = []
         self.tool_log: list[dict[str, Any]] = []
         self.artifact_log: list[dict[str, Any]] = []
+        self.blocks_log: list[dict[str, Any]] = []
 
     async def _send(self, msg: dict[str, Any]) -> None:
         try:
@@ -62,13 +63,15 @@ class WebSocketTurnUI(TurnUI):
 
     async def tool_finished(self, index: int, item: PlanItem) -> None:
         # Save to log
-        self.tool_log.append({
+        tool_entry = {
             "name": item.name,
             "args": item.args,
             "status": item.status,
             "duration_s": item.duration_s,
             "output": item.output[:4000],
-        })
+        }
+        self.tool_log.append(tool_entry)
+        self.blocks_log.append({"type": "tool", **tool_entry})
         await self._send({
             "type": "tool_done",
             "name": item.name,
@@ -90,6 +93,7 @@ class WebSocketTurnUI(TurnUI):
 
     async def thinking_update(self, text: str) -> None:
         self.thinking_log.append(text)
+        self.blocks_log.append({"type": "thinking", "text": text})
         await self._send({"type": "status", "text": "Thinking..."})
         await self._send({"type": "thinking", "text": text})
 
@@ -233,6 +237,7 @@ async def handle_ws_chat(ws: WebSocket) -> None:
                             tool_calls=turn_ui.tool_log,
                             thinking=turn_ui.thinking_log,
                             artifacts=turn_ui.artifact_log,
+                            blocks=turn_ui.blocks_log,
                         )
                         session.truncate()
                         chat_history.save_session(session)

--- a/server/foreman_agent.py
+++ b/server/foreman_agent.py
@@ -37,7 +37,19 @@ from .turn_ui import (  # noqa: F401, E402
 # ---------- system prompt ----------
 
 
+_cached_prompt: str | None = None
+
+
 def _load_system_prompt() -> str:
+    """Return cached system prompt. Built once at first call."""
+    global _cached_prompt
+    if _cached_prompt is not None:
+        return _cached_prompt
+    _cached_prompt = _build_system_prompt()
+    return _cached_prompt
+
+
+def _build_system_prompt() -> str:
     """Load from file + append auto-discovered tool list."""
     base = ""
     if _PROMPT_FILE.exists():
@@ -55,6 +67,13 @@ def _load_system_prompt() -> str:
         pass
 
     return base
+
+
+def reload_prompt() -> str:
+    """Force-rebuild and re-cache the system prompt. Called by reload_tools.py."""
+    global _cached_prompt
+    _cached_prompt = _build_system_prompt()
+    return _cached_prompt
 
 
 # ---------- security hook ----------

--- a/server/render_route.py
+++ b/server/render_route.py
@@ -95,6 +95,14 @@ async def setup_status():
     return {"complete": is_setup_complete()}
 
 
+@app.post("/api/reload-prompt")
+async def reload_prompt():
+    """Force-reload the Foreman system prompt (re-scans tools and workflows)."""
+    from server.foreman_agent import reload_prompt
+    prompt = reload_prompt()
+    return {"reloaded": True, "length": len(prompt)}
+
+
 @app.get("/api/version")
 async def version():
     """Return the newest mtime across all server/pipeline/renderer files."""

--- a/static/imp-chat.js
+++ b/static/imp-chat.js
@@ -252,20 +252,35 @@ async function loadChats() {
 
 function renderTurnFull(turn) {
   let parts = [];
-  if (turn.thinking && turn.thinking.length) {
-    turn.thinking.forEach(t => {
-      const escaped = t.replace(/</g,'&lt;').replace(/>/g,'&gt;');
-      parts.push(`<details class="thinking-block"><summary>Thinking</summary><div class="thinking-content">${escaped}</div></details>`);
+  if (turn.blocks && turn.blocks.length) {
+    // Ordered blocks preserve the interleaved sequence
+    turn.blocks.forEach(b => {
+      if (b.type === 'thinking') {
+        const escaped = b.text.replace(/</g,'&lt;').replace(/>/g,'&gt;');
+        parts.push(`<details class="thinking-block"><summary>Thinking</summary><div class="thinking-content">${escaped}</div></details>`);
+      } else if (b.type === 'tool') {
+        const icon = b.status === 'ok' ? '✅' : (b.status === 'error' ? '❌' : '⏳');
+        const dur = b.duration_s ? ` · ${b.duration_s.toFixed(1)}s` : '';
+        const output = (b.output || '').replace(/</g,'&lt;').replace(/>/g,'&gt;');
+        parts.push(`<details class="tool-block ${b.status || ''}"><summary>${icon} ${b.name}(${formatArgs(b.args || {})})${dur}</summary><pre>${output || '(no output)'}</pre></details>`);
+      }
     });
-  }
-  if (turn.tool_calls && turn.tool_calls.length) {
-    turn.tool_calls.forEach(tc => {
-      const icon = tc.status === 'ok' ? '✅' : (tc.status === 'error' ? '❌' : '⏳');
-      const dur = tc.duration_s ? ` · ${tc.duration_s.toFixed(1)}s` : '';
-      const args = tc.args || {};
-      const output = (tc.output || '').replace(/</g,'&lt;').replace(/>/g,'&gt;');
-      parts.push(`<details class="tool-block ${tc.status || ''}"><summary>${icon} ${tc.name}(${formatArgs(args)})${dur}</summary><pre>${output || '(no output)'}</pre></details>`);
-    });
+  } else {
+    // Fallback for old turns without blocks
+    if (turn.thinking && turn.thinking.length) {
+      turn.thinking.forEach(t => {
+        const escaped = t.replace(/</g,'&lt;').replace(/>/g,'&gt;');
+        parts.push(`<details class="thinking-block"><summary>Thinking</summary><div class="thinking-content">${escaped}</div></details>`);
+      });
+    }
+    if (turn.tool_calls && turn.tool_calls.length) {
+      turn.tool_calls.forEach(tc => {
+        const icon = tc.status === 'ok' ? '✅' : (tc.status === 'error' ? '❌' : '⏳');
+        const dur = tc.duration_s ? ` · ${tc.duration_s.toFixed(1)}s` : '';
+        const output = (tc.output || '').replace(/</g,'&lt;').replace(/>/g,'&gt;');
+        parts.push(`<details class="tool-block ${tc.status || ''}"><summary>${icon} ${tc.name}(${formatArgs(tc.args || {})})${dur}</summary><pre>${output || '(no output)'}</pre></details>`);
+      });
+    }
   }
   if (turn.content) parts.push(turn.content);
   return parts.join('\n\n');

--- a/tools/imp/reload_tools.py
+++ b/tools/imp/reload_tools.py
@@ -1,0 +1,33 @@
+#!/usr/bin/env python3
+"""Reload the cached tool and workflow list.
+
+Inputs: None.
+
+Process: Calls the server's /api/reload-prompt endpoint to force the
+         Foreman agent to re-scan tools/ and workflows/ directories.
+Output: Prints confirmation."""
+import json
+import sys
+import urllib.error
+import urllib.request
+
+
+def main() -> int:
+    url = "http://127.0.0.1:8421/api/reload-prompt"
+    try:
+        req = urllib.request.Request(url, method="POST", data=b"{}")
+        req.add_header("Content-Type", "application/json")
+        with urllib.request.urlopen(req, timeout=5) as resp:
+            data = json.loads(resp.read().decode())
+            print(f"Reloaded. Prompt length: {data.get('length', '?')} chars.")
+            return 0
+    except urllib.error.HTTPError as e:
+        print(f"HTTP {e.code}: {e.read().decode()}", file=sys.stderr)
+        return 1
+    except urllib.error.URLError as e:
+        print(f"Server not reachable: {e.reason}", file=sys.stderr)
+        return 1
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())


### PR DESCRIPTION
## Summary

Two commits that were pushed to the #128 branch after it was merged:

- **Cache tool/workflow list at startup** — prompt built once, `reload_tools.py` to refresh. Fixes #129.
- **Preserve thinking/tool block order** — turns save ordered `blocks` list so reloaded chats show thinking/tools in the original interleaved sequence.

🤖 Generated with [Claude Code](https://claude.com/claude-code)