### PR TITLE
Tool testing panel: Context In, Context Out, Log

### DIFF
--- a/server/render_route.py
+++ b/server/render_route.py
@@ -1377,6 +1377,63 @@ async def run_tool(request: Request):
         return {"ok": False, "error": str(exc)}
 
 
+@app.post("/api/tool-debug")
+async def debug_tool(request: Request):
+    """Run a tool's .step.py template with user-provided context JSON."""
+    import asyncio
+    import time as _time
+
+    data = await request.json()
+    group = data.get("group", "")
+    name = data.get("name", "")
+    context = data.get("context", {})
+
+    step_path = _ROOT / "tools" / group / f"{name}.step.py"
+    if not step_path.exists():
+        return {"ok": False, "error": f"No step template: {group}/{name}.step.py"}
+
+    # Run the step in a subprocess to isolate it
+    runner_code = f"""
+import json, sys, importlib.util, time
+spec = importlib.util.spec_from_file_location("step", {str(step_path)!r})
+mod = importlib.util.module_from_spec(spec)
+spec.loader.exec_module(mod)
+context = json.loads(sys.stdin.read())
+t0 = time.time()
+try:
+    result = mod.run(context)
+    dur = time.time() - t0
+    print(json.dumps({{"ok": True, "result": result, "duration_s": round(dur, 2)}}))
+except Exception as e:
+    dur = time.time() - t0
+    print(json.dumps({{"ok": False, "error": str(e), "duration_s": round(dur, 2)}}))
+"""
+
+    try:
+        proc = await asyncio.create_subprocess_exec(
+            sys.executable, "-c", runner_code,
+            stdin=asyncio.subprocess.PIPE,
+            stdout=asyncio.subprocess.PIPE,
+            stderr=asyncio.subprocess.PIPE,
+            cwd=str(_ROOT),
+        )
+        stdout, stderr = await asyncio.wait_for(
+            proc.communicate(input=json.dumps(context).encode()),
+            timeout=30,
+        )
+        try:
+            result = json.loads(stdout.decode())
+        except json.JSONDecodeError:
+            result = {"ok": False, "error": "Invalid output", "stdout": stdout.decode()[:2000]}
+        result["stderr"] = stderr.decode()[:2000]
+        return result
+    except asyncio.TimeoutError:
+        proc.kill()
+        return {"ok": False, "error": "Timed out after 30 seconds"}
+    except Exception as exc:
+        return {"ok": False, "error": str(exc)}
+
+
 def _renumber_steps(wf_dir: Path) -> None:
     import re
     steps = sorted(wf_dir.glob("step_*.py"))

--- a/server/render_route.py
+++ b/server/render_route.py
@@ -1387,14 +1387,19 @@ async def debug_tool(request: Request):
     group = data.get("group", "")
     name = data.get("name", "")
     context = data.get("context", {})
+    params = data.get("params", {})
+
+    # Merge params into context so the step sees them
+    context.update(params)
 
     step_path = _ROOT / "tools" / group / f"{name}.step.py"
     if not step_path.exists():
         return {"ok": False, "error": f"No step template: {group}/{name}.step.py"}
 
     # Run the step in a subprocess to isolate it
+    # Returns both the step result and the context after running
     runner_code = f"""
-import json, sys, importlib.util, time
+import json, sys, importlib.util, time, copy
 spec = importlib.util.spec_from_file_location("step", {str(step_path)!r})
 mod = importlib.util.module_from_spec(spec)
 spec.loader.exec_module(mod)
@@ -1403,7 +1408,13 @@ t0 = time.time()
 try:
     result = mod.run(context)
     dur = time.time() - t0
-    print(json.dumps({{"ok": True, "result": result, "duration_s": round(dur, 2)}}))
+    # Build context_out: original context with result appended to previous_results
+    ctx_out = copy.deepcopy(context)
+    prev = ctx_out.get("previous_results", {{}})
+    if isinstance(prev, dict):
+        prev[ctx_out.get("step", "debug")] = result
+    ctx_out["previous_results"] = prev
+    print(json.dumps({{"ok": True, "result": result, "context_out": ctx_out, "duration_s": round(dur, 2)}}, default=str))
 except Exception as e:
     dur = time.time() - t0
     print(json.dumps({{"ok": False, "error": str(e), "duration_s": round(dur, 2)}}))

--- a/static/imp-tools.js
+++ b/static/imp-tools.js
@@ -102,6 +102,7 @@ async function loadToolsPanel() {
           if (data.docstring) inner += `<div style="font-size:12px;color:var(--muted);margin-bottom:8px;">${marked.parse(data.docstring)}</div>`;
           if (data.source) inner += imp.fold('Script', imp.code(data.source));
           if (data.step_template) inner += imp.fold('Workflow template', imp.code(data.step_template));
+          if (data.step_template) inner += imp.fold('Testing', buildTestingPanel(tGroup, tName));
           container.innerHTML = inner || '<em style="color:var(--muted);">No source</em>';
         } catch (e) {
           container.innerHTML = `<em style="color:#da3633;">Failed to load</em>`;
@@ -210,4 +211,74 @@ function deleteToolScript(group, name) {
     body: JSON.stringify({group, name}) })
     .then(r => r.json()).then(d => { if (d.error) alert('Delete failed: ' + d.error); loadToolsPanel(); })
     .catch(e => alert('Delete failed: ' + e));
+}
+
+function buildTestingPanel(group, name) {
+  var defaultCtx = '{"previous_results": []}';
+  var runBtn = imp.btn('Run', "runToolDebug('" + group + "','" + name + "')", {cls:'primary'});
+  return '<div style="display:flex;gap:8px;margin-bottom:8px;">'
+    + '<div style="flex:1;"><label style="font-size:11px;color:var(--muted);">Context In</label>'
+    + '<textarea class="wf-readme-edit tool-ctx-in" data-group="' + group + '" data-name="' + name + '" style="min-height:100px;font-family:monospace;font-size:11px;">' + defaultCtx + '</textarea></div>'
+    + '<div style="flex:1;"><label style="font-size:11px;color:var(--muted);">Context Out</label>'
+    + '<textarea class="wf-readme-edit tool-ctx-out" data-group="' + group + '" data-name="' + name + '" style="min-height:100px;font-family:monospace;font-size:11px;"></textarea></div>'
+    + '</div>'
+    + '<div style="display:flex;align-items:center;gap:8px;margin-bottom:8px;">'
+    + runBtn
+    + '<span class="tool-debug-status" data-group="' + group + '" data-name="' + name + '" style="font-size:11px;color:var(--muted);"></span>'
+    + '</div>'
+    + '<div class="tool-debug-log" data-group="' + group + '" data-name="' + name + '" style="display:none;">'
+    + '<label style="font-size:11px;color:var(--muted);">Log</label>'
+    + '<pre class="imp-code" style="max-height:200px;overflow:auto;font-size:11px;"></pre>'
+    + '</div>';
+}
+
+async function runToolDebug(group, name) {
+  var ctxIn = document.querySelector('.tool-ctx-in[data-group="' + group + '"][data-name="' + name + '"]');
+  var ctxOut = document.querySelector('.tool-ctx-out[data-group="' + group + '"][data-name="' + name + '"]');
+  var status = document.querySelector('.tool-debug-status[data-group="' + group + '"][data-name="' + name + '"]');
+  var logDiv = document.querySelector('.tool-debug-log[data-group="' + group + '"][data-name="' + name + '"]');
+  if (!ctxIn) return;
+
+  var context;
+  try {
+    context = JSON.parse(ctxIn.value);
+  } catch (e) {
+    status.textContent = 'Invalid JSON in Context In';
+    status.style.color = '#da3633';
+    return;
+  }
+
+  status.textContent = 'Running...';
+  status.style.color = 'var(--muted)';
+
+  try {
+    var res = await fetch(API + '/api/tool-debug', {
+      method: 'POST', headers: {'Content-Type': 'application/json'},
+      body: JSON.stringify({group: group, name: name, context: context}),
+    });
+    var data = await res.json();
+
+    var icon = data.ok ? '\u2705' : '\u274c';
+    var dur = data.duration_s ? ' \u00b7 ' + data.duration_s + 's' : '';
+    status.textContent = icon + ' ' + (data.ok ? 'OK' : 'Error') + dur;
+    status.style.color = data.ok ? '#3fb950' : '#da3633';
+
+    if (data.result) {
+      ctxOut.value = JSON.stringify(data.result, null, 2);
+    } else if (data.error) {
+      ctxOut.value = data.error;
+    }
+
+    var logText = '';
+    if (data.result && data.result.output) logText += data.result.output + '\n';
+    if (data.stderr) logText += data.stderr;
+    if (data.error) logText += data.error;
+    if (logText.trim()) {
+      logDiv.style.display = '';
+      logDiv.querySelector('pre').textContent = logText.trim();
+    }
+  } catch (e) {
+    status.textContent = 'Request failed: ' + e;
+    status.style.color = '#da3633';
+  }
 }

--- a/static/imp-tools.js
+++ b/static/imp-tools.js
@@ -214,7 +214,7 @@ function deleteToolScript(group, name) {
 }
 
 function buildTestingPanel(group, name) {
-  var defaultCtx = '{"previous_results": []}';
+  var defaultCtx = '{\n  "previous_results": {},\n  "workflow": "test",\n  "step": "' + name + '"\n}';
   var runBtn = imp.btn('Run', "runToolDebug('" + group + "','" + name + "')", {cls:'primary'});
   return '<div style="display:flex;gap:8px;margin-bottom:8px;">'
     + '<div style="flex:1;"><label style="font-size:11px;color:var(--muted);">Context In</label>'

--- a/static/imp-tools.js
+++ b/static/imp-tools.js
@@ -215,12 +215,15 @@ function deleteToolScript(group, name) {
 
 function buildTestingPanel(group, name) {
   var defaultCtx = '{\n  "previous_results": {},\n  "workflow": "test",\n  "step": "' + name + '"\n}';
+  var defaultParams = '{}';
   var runBtn = imp.btn('Run', "runToolDebug('" + group + "','" + name + "')", {cls:'primary'});
   return '<div style="display:flex;gap:8px;margin-bottom:8px;">'
     + '<div style="flex:1;"><label style="font-size:11px;color:var(--muted);">Context In</label>'
-    + '<textarea class="wf-readme-edit tool-ctx-in" data-group="' + group + '" data-name="' + name + '" style="min-height:100px;font-family:monospace;font-size:11px;">' + defaultCtx + '</textarea></div>'
+    + '<textarea class="wf-readme-edit tool-ctx-in" data-group="' + group + '" data-name="' + name + '" style="min-height:80px;font-family:monospace;font-size:11px;">' + defaultCtx + '</textarea></div>'
+    + '<div style="flex:1;"><label style="font-size:11px;color:var(--muted);">Parameters</label>'
+    + '<textarea class="wf-readme-edit tool-params" data-group="' + group + '" data-name="' + name + '" style="min-height:80px;font-family:monospace;font-size:11px;">' + defaultParams + '</textarea></div>'
     + '<div style="flex:1;"><label style="font-size:11px;color:var(--muted);">Context Out</label>'
-    + '<textarea class="wf-readme-edit tool-ctx-out" data-group="' + group + '" data-name="' + name + '" style="min-height:100px;font-family:monospace;font-size:11px;"></textarea></div>'
+    + '<textarea class="wf-readme-edit tool-ctx-out" data-group="' + group + '" data-name="' + name + '" style="min-height:80px;font-family:monospace;font-size:11px;"></textarea></div>'
     + '</div>'
     + '<div style="display:flex;align-items:center;gap:8px;margin-bottom:8px;">'
     + runBtn
@@ -234,16 +237,24 @@ function buildTestingPanel(group, name) {
 
 async function runToolDebug(group, name) {
   var ctxIn = document.querySelector('.tool-ctx-in[data-group="' + group + '"][data-name="' + name + '"]');
+  var paramsEl = document.querySelector('.tool-params[data-group="' + group + '"][data-name="' + name + '"]');
   var ctxOut = document.querySelector('.tool-ctx-out[data-group="' + group + '"][data-name="' + name + '"]');
   var status = document.querySelector('.tool-debug-status[data-group="' + group + '"][data-name="' + name + '"]');
   var logDiv = document.querySelector('.tool-debug-log[data-group="' + group + '"][data-name="' + name + '"]');
   if (!ctxIn) return;
 
-  var context;
+  var context, params;
   try {
     context = JSON.parse(ctxIn.value);
   } catch (e) {
     status.textContent = 'Invalid JSON in Context In';
+    status.style.color = '#da3633';
+    return;
+  }
+  try {
+    params = JSON.parse(paramsEl.value || '{}');
+  } catch (e) {
+    status.textContent = 'Invalid JSON in Parameters';
     status.style.color = '#da3633';
     return;
   }
@@ -254,7 +265,7 @@ async function runToolDebug(group, name) {
   try {
     var res = await fetch(API + '/api/tool-debug', {
       method: 'POST', headers: {'Content-Type': 'application/json'},
-      body: JSON.stringify({group: group, name: name, context: context}),
+      body: JSON.stringify({group: group, name: name, context: context, params: params}),
     });
     var data = await res.json();
 
@@ -263,8 +274,8 @@ async function runToolDebug(group, name) {
     status.textContent = icon + ' ' + (data.ok ? 'OK' : 'Error') + dur;
     status.style.color = data.ok ? '#3fb950' : '#da3633';
 
-    if (data.result) {
-      ctxOut.value = JSON.stringify(data.result, null, 2);
+    if (data.context_out) {
+      ctxOut.value = JSON.stringify(data.context_out, null, 2);
     } else if (data.error) {
       ctxOut.value = data.error;
     }


### PR DESCRIPTION
## Summary

- **Testing fold** added below Script and Workflow Template in tool detail
- **Context In** — editable JSON textarea, defaults to `{"previous_results": []}`
- **Context Out** — shows the result after running, editable
- **Log** — shows output/stderr from the run
- **Run button** — calls `POST /api/tool-debug` which runs the `.step.py` with the provided context
- Only shows for tools that have a `.step.py` template

Fixes #108

## Test plan

- [x] Open a tool that has a `.step.py` — Testing fold should appear
- [x] Edit Context In, click Run — Context Out and Log should fill
- [x] Tool without `.step.py` — no Testing fold
- [x] Invalid JSON in Context In — shows error in status

🤖 Generated with [Claude Code](https://claude.com/claude-code)