### PR TITLE
Self-contained chat folders with artifacts

### DIFF
--- a/server/chat_history.py
+++ b/server/chat_history.py
@@ -159,13 +159,23 @@ class ChatSession:
             "turns": [t.to_dict() for t in self.turns],
         }
 
-    def filename(self) -> str:
-        """`<created_at_safe>_<id>.json` — chronological sort works with
-        a plain `ls` because ISO timestamps sort lexically."""
-        return f"{_safe_stem(self.created_at)}_{self.id}.json"
+    def folder(self, base: Optional[Path] = None) -> Path:
+        """Return the chat folder: `.imp/chats/<id>/`."""
+        return (base or CHATS_DIR) / self.id
 
     def path(self, base: Optional[Path] = None) -> Path:
-        return (base or CHATS_DIR) / self.filename()
+        """Return the chat JSON path: `.imp/chats/<id>/chat.json`."""
+        return self.folder(base) / "chat.json"
+
+    def artifacts_dir(self, base: Optional[Path] = None) -> Path:
+        """Return the artifacts folder, creating it if needed."""
+        d = self.folder(base) / "artifacts"
+        d.mkdir(parents=True, exist_ok=True)
+        return d
+
+    # Legacy compat
+    def _legacy_path(self, base: Optional[Path] = None) -> Path:
+        return (base or CHATS_DIR) / f"{_safe_stem(self.created_at)}_{self.id}.json"
 
     # ---- mutation ----
 
@@ -244,11 +254,11 @@ def ensure_chats_dir(base: Optional[Path] = None) -> Path:
 
 
 def save_session(session: ChatSession, *, base: Optional[Path] = None) -> Path:
-    """Write the session as pretty-printed JSON. Overwrites the file
-    atomically — write to a sibling tempfile then rename, so a crash
-    mid-write can't leave a half-written chat on disk.
+    """Write the session as pretty-printed JSON inside its folder.
+    `.imp/chats/<id>/chat.json`. Atomic write via tempfile rename.
     """
-    ensure_chats_dir(base)
+    folder = session.folder(base)
+    folder.mkdir(parents=True, exist_ok=True)
     final = session.path(base)
     tmp = final.with_suffix(final.suffix + ".tmp")
     tmp.write_text(json.dumps(session.to_dict(), indent=2))
@@ -257,56 +267,68 @@ def save_session(session: ChatSession, *, base: Optional[Path] = None) -> Path:
 
 
 def load_session(chat_id: str, *, base: Optional[Path] = None) -> Optional[ChatSession]:
-    """Load a session by `chat_id`. Matches the `_<id>.json` suffix so
-    callers don't need to know the created_at prefix."""
+    """Load a session by `chat_id`. Checks folder format first, then legacy flat file."""
     d = base or CHATS_DIR
     if not d.exists():
         return None
+
+    # New format: .imp/chats/<id>/chat.json
+    folder_path = d / chat_id / "chat.json"
+    if folder_path.exists():
+        try:
+            return ChatSession.from_dict(json.loads(folder_path.read_text()))
+        except (json.JSONDecodeError, KeyError) as exc:
+            print(f"[chat_history] corrupt {folder_path}: {exc}", file=sys.stderr)
+            return None
+
+    # Legacy format: .imp/chats/*_<id>.json
     for path in d.glob(f"*_{chat_id}.json"):
         try:
-            return ChatSession.from_dict(json.loads(path.read_text()))
+            session = ChatSession.from_dict(json.loads(path.read_text()))
+            # Migrate: save in new format, remove old file
+            save_session(session, base=base)
+            path.unlink()
+            print(f"[chat_history] migrated {path.name} → {chat_id}/chat.json", file=sys.stderr)
+            return session
         except (json.JSONDecodeError, KeyError) as exc:
-            print(
-                f"[chat_history] corrupt session file {path.name}: "
-                f"{type(exc).__name__}: {exc}",
-                file=sys.stderr,
-            )
+            print(f"[chat_history] corrupt {path.name}: {exc}", file=sys.stderr)
             return None
     return None
 
 
-def asset_dir(chat_id: str, *, base: Optional[Path] = None) -> Path:
-    """Return the asset folder for a session, creating it if needed."""
-    d = (base or CHATS_DIR) / chat_id
+def artifacts_dir(chat_id: str, *, base: Optional[Path] = None) -> Path:
+    """Return the artifacts folder for a chat, creating it if needed."""
+    d = (base or CHATS_DIR) / chat_id / "artifacts"
     d.mkdir(parents=True, exist_ok=True)
     return d
 
 
 def delete_session(chat_id: str, *, base: Optional[Path] = None) -> bool:
-    """Delete a session file + asset folder by id."""
+    """Delete a chat folder (or legacy flat file). Everything goes."""
     import shutil
 
     d = base or CHATS_DIR
     if not d.exists():
         return False
     deleted = False
+
+    # New format: delete the whole folder
+    folder = d / chat_id
+    if folder.is_dir():
+        try:
+            shutil.rmtree(folder)
+            deleted = True
+        except OSError as exc:
+            print(f"[chat_history] delete failed for {folder}: {exc}", file=sys.stderr)
+
+    # Legacy flat files
     for path in d.glob(f"*_{chat_id}.json"):
         try:
             path.unlink()
             deleted = True
         except OSError as exc:
-            print(
-                f"[chat_history] delete failed for {path.name}: "
-                f"{type(exc).__name__}: {exc}",
-                file=sys.stderr,
-            )
-    # Remove asset folder
-    asset_path = d / chat_id
-    if asset_path.is_dir():
-        try:
-            shutil.rmtree(asset_path)
-        except OSError:
-            pass
+            print(f"[chat_history] delete failed for {path.name}: {exc}", file=sys.stderr)
+
     return deleted
 
 
@@ -352,12 +374,43 @@ def list_sessions(
     if not d.exists():
         return []
     rows: list[dict[str, Any]] = []
+    seen_ids: set[str] = set()
+
+    # New format: .imp/chats/<id>/chat.json
+    for subdir in d.iterdir():
+        if not subdir.is_dir() or subdir.name.startswith(("_", ".")):
+            continue
+        chat_json = subdir / "chat.json"
+        if not chat_json.exists():
+            continue
+        try:
+            data = json.loads(chat_json.read_text())
+            cid = str(data.get("id") or "")
+            seen_ids.add(cid)
+            rows.append(
+                {
+                    "id": cid,
+                    "title": str(data.get("title") or FALLBACK_TITLE),
+                    "title_source": str(data.get("title_source") or "fallback"),
+                    "last_active_at": str(data.get("last_active_at") or ""),
+                    "created_at": str(data.get("created_at") or ""),
+                    "turn_count": len(data.get("turns") or []),
+                    "path": str(chat_json),
+                }
+            )
+        except (json.JSONDecodeError, KeyError) as exc:
+            print(f"[chat_history] skipping unreadable {chat_json}: {exc}", file=sys.stderr)
+
+    # Legacy format: .imp/chats/*_<id>.json
     for path in d.glob("*.json"):
         try:
             data = json.loads(path.read_text())
+            cid = str(data.get("id") or "")
+            if cid in seen_ids:
+                continue
             rows.append(
                 {
-                    "id": str(data.get("id") or ""),
+                    "id": cid,
                     "title": str(data.get("title") or FALLBACK_TITLE),
                     "title_source": str(data.get("title_source") or "fallback"),
                     "last_active_at": str(data.get("last_active_at") or ""),

--- a/server/render_route.py
+++ b/server/render_route.py
@@ -326,6 +326,37 @@ async def delete_chat(chat_id: str):
     return {"deleted": ok}
 
 
+@app.get("/api/chats/{chat_id}/artifacts")
+async def list_artifacts(chat_id: str):
+    """List all artifact files in a chat's artifacts/ folder."""
+    from server import chat_history
+    d = chat_history.artifacts_dir(chat_id)
+    files = []
+    if d.exists():
+        for f in sorted(d.rglob("*")):
+            if f.is_file():
+                files.append({
+                    "name": f.name,
+                    "path": str(f.relative_to(d)),
+                    "size": f.stat().st_size,
+                    "url": f"/api/chats/{chat_id}/artifacts/{f.relative_to(d)}",
+                })
+    return {"artifacts": files, "count": len(files)}
+
+
+@app.get("/api/chats/{chat_id}/artifacts/{path:path}")
+async def serve_artifact(chat_id: str, path: str):
+    """Serve an artifact file with download header."""
+    from server import chat_history
+    d = chat_history.artifacts_dir(chat_id)
+    full = d / path
+    if not full.is_file() or not str(full.resolve()).startswith(str(d.resolve())):
+        return Response("not found", status_code=404)
+    import mimetypes
+    ct = mimetypes.guess_type(full.name)[0] or "application/octet-stream"
+    return FileResponse(full, media_type=ct)
+
+
 # ── queue API ───────────────────────────────────────────────────────
 
 @app.get("/api/queue")

--- a/static/imp-chat.js
+++ b/static/imp-chat.js
@@ -75,7 +75,7 @@ function renderMd(text) {
     } else if (src.includes('/public/charts/')) {
       linkUrl = src;
     }
-    return `<a href="${linkUrl}" target="_blank" title="Open in new tab"><img src="${src}"${rest}></a>`;
+    return `<span style="position:relative;display:inline-block;"><a href="${linkUrl}" target="_blank" title="Open in new tab"><img src="${src}"${rest}></a><a href="${src}" download style="position:absolute;top:4px;right:4px;background:rgba(0,0,0,0.6);color:#fff;padding:2px 6px;border-radius:4px;font-size:10px;text-decoration:none;cursor:pointer;" title="Download PNG">⬇</a></span>`;
   });
   return html;
 }

--- a/static/imp-chat.js
+++ b/static/imp-chat.js
@@ -59,7 +59,7 @@ function renderMd(text) {
     const encoded = encodeURIComponent(diagram.trim());
     const imgUrl = `${API}/render/mermaid?diagram=${encoded}`;
     const viewUrl = `${API}/render/mermaid?diagram=${encoded}&mode=viewer`;
-    return `<a href="${viewUrl}" target="_blank"><img src="${imgUrl}" alt="mermaid diagram"></a>`;
+    return `<span style="position:relative;display:inline-block;"><a href="${viewUrl}" target="_blank"><img src="${imgUrl}" alt="mermaid diagram"></a><a href="${imgUrl}" download style="position:absolute;top:4px;right:4px;background:rgba(0,0,0,0.6);color:#fff;padding:2px 6px;border-radius:4px;font-size:10px;text-decoration:none;cursor:pointer;" title="Download PNG">⬇</a></span>`;
   });
   let html = marked.parse(text);
   toolBlocks.forEach((block, i) => {


### PR DESCRIPTION
## Summary

Each chat is now a self-contained folder. Delete the chat = delete everything it created.

### Storage format
```
.imp/chats/<id>/
  chat.json      — conversation history
  artifacts/     — charts, tables, generated files
```

### Changes
- **chat_history.py** — folders instead of flat files, `artifacts_dir()`, auto-migrate legacy chats on load
- **render_route.py** — `GET /api/chats/<id>/artifacts` lists artifacts, `GET /api/chats/<id>/artifacts/<path>` serves them
- **imp-chat.js** — download button (⬇) on rendered images in chat
- **Backward compat** — old `*_<id>.json` files auto-migrate to folder format on first load

Fixes #136

## Test plan

- [x] New chats save to `.imp/chats/<id>/chat.json`
- [x] Old flat-file chats auto-migrate when opened
- [x] Delete chat removes the entire folder
- [x] Download button appears on chart images
- [x] `/api/chats/<id>/artifacts` lists files

🤖 Generated with [Claude Code](https://claude.com/claude-code)