### PR TITLE
Write approval: show file content, single-column for new files (#154)

### DIFF
--- a/server/foreman_agent.py
+++ b/server/foreman_agent.py
@@ -112,8 +112,8 @@ def _make_security_hook(confirm: Optional[ConfirmFn] = None):
                     desc = f"Edit {file_path}"
                 else:
                     content = tool_input.get("content", "")
-                    line_count = len(content.splitlines())
-                    preview = f"New file: {line_count} lines, {len(content)} chars"
+                    lines = content.splitlines()
+                    preview = "@@ -0,0 +1," + str(len(lines)) + " @@\n" + "\n".join("+" + l for l in lines)
                     desc = f"Write {file_path}"
                 approved = await confirm(tool_name, desc, preview)
                 if not approved:

--- a/static/imp-chat.js
+++ b/static/imp-chat.js
@@ -8,6 +8,10 @@ function renderDiff(text) {
   var lines = text.split('\n');
   var rows = '';
   var oldN = 0, newN = 0;
+  // Detect new-file diffs (all content lines are +, no - lines)
+  var isNewFile = lines.some(function(l) { return l.startsWith('+'); }) &&
+                  !lines.some(function(l) { return l.startsWith('-'); });
+  var cols = isNewFile ? 2 : 3; // single line-number col for new files
   for (var i = 0; i < lines.length; i++) {
     var line = lines[i];
     var bg, sign, lOld, lNew, content;
@@ -16,7 +20,7 @@ function renderDiff(text) {
       if (m) { oldN = parseInt(m[1]) - 1; }
       m = line.match(/\+(\d+)/);
       if (m) { newN = parseInt(m[1]) - 1; }
-      rows += '<tr style="background:#1e3a5f;"><td colspan="3" style="padding:2px 8px;font-size:10px;color:#58a6ff;font-family:monospace;">' + line + '</td></tr>';
+      rows += '<tr style="background:#1e3a5f;"><td colspan="' + cols + '" style="padding:2px 8px;font-size:10px;color:#58a6ff;font-family:monospace;">' + (isNewFile ? 'new file' : line) + '</td></tr>';
       continue;
     }
     if (line.startsWith('-')) {
@@ -41,10 +45,16 @@ function renderDiff(text) {
       lNew = newN;
       content = line.startsWith(' ') ? line.substring(1) : line;
     }
-    rows += '<tr style="background:' + bg + ';">' +
-      '<td style="padding:0 6px;font-size:10px;color:var(--muted);text-align:right;user-select:none;min-width:28px;font-family:monospace;">' + lOld + '</td>' +
-      '<td style="padding:0 6px;font-size:10px;color:var(--muted);text-align:right;user-select:none;min-width:28px;font-family:monospace;">' + lNew + '</td>' +
-      '<td style="padding:0 4px;font-family:monospace;font-size:11px;white-space:pre-wrap;">' + sign + content + '</td></tr>';
+    if (isNewFile) {
+      rows += '<tr style="background:' + bg + ';">' +
+        '<td style="padding:0 6px;font-size:10px;color:var(--muted);text-align:right;user-select:none;min-width:28px;font-family:monospace;">' + lNew + '</td>' +
+        '<td style="padding:0 4px;font-family:monospace;font-size:11px;white-space:pre-wrap;">' + content + '</td></tr>';
+    } else {
+      rows += '<tr style="background:' + bg + ';">' +
+        '<td style="padding:0 6px;font-size:10px;color:var(--muted);text-align:right;user-select:none;min-width:28px;font-family:monospace;">' + lOld + '</td>' +
+        '<td style="padding:0 6px;font-size:10px;color:var(--muted);text-align:right;user-select:none;min-width:28px;font-family:monospace;">' + lNew + '</td>' +
+        '<td style="padding:0 4px;font-family:monospace;font-size:11px;white-space:pre-wrap;">' + sign + content + '</td></tr>';
+    }
   }
   return '<table style="width:100%;border-collapse:collapse;border-spacing:0;">' + rows + '</table>';
 }


### PR DESCRIPTION
## Summary
- **Backend**: Write preview now sends actual file content as `+`-prefixed diff lines instead of just "New file: 3 lines, 158 chars"
- **Frontend**: Detects new-file diffs (all `+`, no `-`) and renders with a single line-number column, no `+`/`-` signs — clean file preview instead of the two-column diff format

Closes #154

## Test plan
- [x] Ask the agent to write a new file — approval should show the full file content with line numbers
- [x] Ask the agent to edit an existing file — approval should still show the two-column diff as before
- [x] Verify long files are scrollable in the preview

🤖 Generated with [Claude Code](https://claude.com/claude-code)