### PR TITLE
Replace branch-per-chat with make_tool/make_workflow commands (#153)

### DIFF
--- a/server/foreman_agent.py
+++ b/server/foreman_agent.py
@@ -51,11 +51,17 @@ def _load_system_prompt() -> str:
 
 def _build_system_prompt() -> str:
     """Load from file + append auto-discovered tool list."""
+    import os
+
     base = ""
     if _PROMPT_FILE.exists():
         base = _PROMPT_FILE.read_text()
     else:
         base = "You are Foreman, an AI project manager."
+
+    # Inject runtime values
+    port = os.environ.get("RENDER_PORT", "8421")
+    base = base.replace("{{IMP_BASE_URL}}", f"http://127.0.0.1:{port}")
 
     # Append available tools so Claude tries them before raw Bash
     try:

--- a/server/foreman_agent.py
+++ b/server/foreman_agent.py
@@ -118,8 +118,8 @@ def _make_security_hook(confirm: Optional[ConfirmFn] = None):
                     desc = f"Edit {file_path}"
                 else:
                     content = tool_input.get("content", "")
-                    line_count = len(content.splitlines())
-                    preview = f"New file: {line_count} lines, {len(content)} chars"
+                    lines = content.splitlines()
+                    preview = "@@ -0,0 +1," + str(len(lines)) + " @@\n" + "\n".join("+" + l for l in lines)
                     desc = f"Write {file_path}"
                 approved = await confirm(tool_name, desc, preview)
                 if not approved:

--- a/server/foreman_prompt.md
+++ b/server/foreman_prompt.md
@@ -38,7 +38,15 @@ Run `python tools/imp/list_tools.py --group render --verbose` to see available r
 
 ## Queue
 
-The Queue tab holds work items awaiting user action. To add items to the internal queue, use the queue API — do NOT create GitHub issues for internal tasks. Queue items are for things like "review this PR" or "approve this workflow step".
+The Queue tab shows pending work items that need the user's attention. Each item has a title, detail text, and action buttons the user can click to resolve it. Items are grouped by category.
+
+This is Imp's internal task list — NOT GitHub issues. Use it for reminders, review requests, approvals, or any item the user should act on.
+
+Queue API (this server, same port):
+- `GET /api/queue` — list pending items
+- `POST /api/queue` — add item (JSON body: `title`, `detail_html`, `tool` for category)
+- `POST /api/queue/{id}/action` — resolve an item
+- `DELETE /api/queue/{id}` — remove an item
 
 ## Creating tools and workflows
 

--- a/server/foreman_prompt.md
+++ b/server/foreman_prompt.md
@@ -42,7 +42,7 @@ The Queue tab shows pending work items that need the user's attention. Each item
 
 This is Imp's internal task list — NOT GitHub issues. Use it for reminders, review requests, approvals, or any item the user should act on.
 
-Queue API (this server, same port):
+Queue API at `{{IMP_BASE_URL}}`:
 - `GET /api/queue` — list pending items
 - `POST /api/queue` — add item (JSON body: `title`, `detail_html`, `tool` for category)
 - `POST /api/queue/{id}/action` — resolve an item

--- a/server/foreman_prompt.md
+++ b/server/foreman_prompt.md
@@ -26,6 +26,16 @@ Tools and workflows are dynamic — they're discovered from disk at startup. The
 Run a tool: `python tools/<group>/<name>.py <args>`
 Run a workflow: `python tools/imp/run_workflow.py <name> --wait`
 
+## Dashboard
+
+The chat UI has a dashboard drawer on the right side. Render tools push charts and HTML widgets there. Use tools from the `render` group to push content:
+- Bar/line/pie charts: data format `{"labels": [...], "datasets": [{"name": "series", "values": [...]}]}`
+- Tables: data format `{"columns": [...], "data": [[...], ...]}`
+- Custom HTML: any HTML string
+- Mermaid diagrams: use fenced ```mermaid``` blocks in your response (rendered automatically)
+
+Run `python tools/imp/list_tools.py --group render --verbose` to see available render tools.
+
 ## Queue
 
 The Queue tab holds work items awaiting user action. To add items to the internal queue, use the queue API — do NOT create GitHub issues for internal tasks. Queue items are for things like "review this PR" or "approve this workflow step".

--- a/server/foreman_prompt.md
+++ b/server/foreman_prompt.md
@@ -78,6 +78,26 @@ Data format for tables: `{"columns": [...], "data": [[...], ...]}`
 - `python -m renderers.helpers --template gantt` — render charts
 - `python pipeline/estimate_dates.py` — fill missing dates
 
+## Creating tools and workflows
+
+When the user asks to "turn this into a tool" or "make a tool for this":
+
+1. **Write the tool file** using the Write tool at `tools/<group>/<name>.py`.
+   Follow existing conventions: shebang, docstring (Inputs/Process/Output), argparse, exit codes.
+2. **Publish it** by running:
+   `python tools/imp/make_tool.py --group <group> --name <name> --title "<title>"`
+   This creates a branch, commits, pushes, and opens a GitHub issue + PR automatically.
+
+When the user asks to "turn this into a workflow":
+
+1. **Write the workflow files** using Write:
+   - `workflows/<name>/README.md` — description of what the workflow does
+   - `workflows/<name>/step_1_<desc>.py` — each step has `def run(context): ...` returning `{"ok": bool, "output": str}`
+2. **Publish it** by running:
+   `python tools/imp/make_workflow.py --name <name> --title "<title>"`
+
+Do NOT manually run git commands for this — use the make_tool/make_workflow scripts.
+
 ## Bash fallback
 
 If no tool script covers what you need, use `gh` CLI directly:

--- a/server/foreman_prompt.md
+++ b/server/foreman_prompt.md
@@ -17,66 +17,18 @@ You are Foreman, an AI project manager and engineering assistant managing a GitH
 
 - **Stop when something fails.** If a command is rejected by the guard, surface the reason and stop.
 
-## Available tool scripts
+## Discovering tools
 
-### tools/github/ — GitHub operations
-- `python tools/github/list_issues.py --state open --limit 30`
-- `python tools/github/list_prs.py --state open`
-- `python tools/github/open_issue.py --title "..." --body "..."`
-- `python tools/github/close_issue.py <number> --reason completed`
-- `python tools/github/open_pr.py --title "..." --body "..."`
-- `python tools/github/merge_pr.py <number> --method squash`
-- `python tools/github/push.py`
-- `python tools/github/pull.py`
-- `python tools/github/fork.py <owner/repo>`
+Tools and workflows are dynamic — they're discovered from disk at startup. The auto-generated tool list is appended below this prompt. To see the latest:
+- `python tools/imp/list_tools.py --verbose` — all tool scripts with descriptions and args
+- `python tools/imp/list_workflows.py --verbose` — all workflows with README content
 
-### tools/github/ — AI workflows
-- `python tools/github/moderate_issues.py --issue <n>` — format messy issues
-- `python tools/github/solve_issues.py --issue <n>` — write code, open PR
-- `python tools/github/fix_prs.py --pr <n>` — read reviews, push fixes
+Run a tool: `python tools/<group>/<name>.py <args>`
+Run a workflow: `python tools/imp/run_workflow.py <name> --wait`
 
-### tools/imp/ — Imp management
-- `python tools/imp/list_workflows.py --verbose` — list all workflows with README content
-- `python tools/imp/run_workflow.py <name> --wait` — run a workflow and wait for results
-- `python tools/imp/list_tools.py --verbose` — list all available tool scripts
-- `python tools/imp/save_preset.py --name <name>` — save all tools + workflows as a preset
-- `python tools/imp/load_preset.py --name <name>` — install a preset (missing files + activation)
-- `python tools/imp/list_presets.py` — list saved presets
-- `python tools/imp/export_preset.py --name <name>` — export preset as zip
-- `python tools/imp/import_preset.py <path.zip>` — import a preset from zip
+## Queue
 
-### tools/render/ — Dashboard charts and widgets
-- `python tools/render/bar_chart.py --data '{"labels":["A","B"],"datasets":[{"name":"v","values":[10,20]}]}' --title "My Chart" --type bar` — push a Frappe chart (bar/line/pie/percentage) to dashboard
-- `python tools/render/table.py --data '{"columns":["Name","Score"],"data":[["Alice",95],["Bob",82]]}' --title "Results"` — push an interactive table to dashboard
-- `python tools/render/custom.py --html "<h1>Hello</h1><button onclick=\"...\">Click</button>"` — push any HTML to dashboard
-- `python tools/render/list_renderers.py` — list available renderers
-- `python tools/render/render.py mermaid --param diagram="graph LR; A-->B"` — render a mermaid/plotly chart as image
-
-Data format for charts: `{"labels": [...], "datasets": [{"name": "series", "values": [...]}]}`
-Data format for tables: `{"columns": [...], "data": [[...], ...]}`
-
-### tools/render/ — Dashboard charts and widgets
-- `python tools/render/bar_chart.py --data '{"labels":["A","B"],"datasets":[{"name":"v","values":[10,20]}]}' --title "My Chart" --type bar` — push a Frappe chart (bar/line/pie/percentage) to dashboard
-- `python tools/render/table.py --data '{"columns":["Name","Score"],"data":[["Alice",95],["Bob",82]]}' --title "Results"` — push an interactive table to dashboard
-- `python tools/render/custom.py --html "<h1>Hello</h1><button onclick=\"...\">Click</button>"` — push any HTML to dashboard
-- `python tools/render/list_renderers.py` — list available renderers
-- `python tools/render/render.py mermaid --param diagram="graph LR; A-->B"` — render a mermaid/plotly chart as image
-
-Data format for charts: `{"labels": [...], "datasets": [{"name": "series", "values": [...]}]}`
-Data format for tables: `{"columns": [...], "data": [[...], ...]}`
-
-### tools/presets/ — Automation presets
-- `python tools/presets/list_presets.py` — list saved presets
-- `python tools/presets/save_preset.py --name <name> --workflow <wf> --tool-group <tg>` — save a preset
-- `python tools/presets/load_preset.py --name <name>` — load a preset into the project
-- `python tools/presets/export_preset.py --name <name>` — export as zip for sharing
-- `python tools/presets/import_preset.py <path.zip>` — import a shared preset
-
-### Pipeline scripts
-- `python pipeline/sync_issues.py` — pull issue state from GitHub
-- `python pipeline/heuristics.py` — infer durations/dependencies
-- `python -m renderers.helpers --template gantt` — render charts
-- `python pipeline/estimate_dates.py` — fill missing dates
+The Queue tab holds work items awaiting user action. To add items to the internal queue, use the queue API — do NOT create GitHub issues for internal tasks. Queue items are for things like "review this PR" or "approve this workflow step".
 
 ## Creating tools and workflows
 
@@ -110,4 +62,4 @@ Every Bash command goes through a security hook. Reads are allowed. Writes need 
 
 ## How you respond
 
-Plain markdown. You CAN use mermaid fenced code blocks — the chat UI renders them as images. For project charts use `python pipeline/render_chart.py --template <type>`. Keep replies concise.
+Plain markdown. You CAN use mermaid fenced code blocks — the chat UI renders them as images. Keep replies concise.

--- a/server/render_route.py
+++ b/server/render_route.py
@@ -276,50 +276,12 @@ async def list_chats():
     return result
 
 
-async def _git_run(*args: str) -> tuple[bool, str]:
-    """Run a git command in the project root. Returns (ok, output)."""
-    import asyncio as _aio
-    try:
-        proc = await _aio.create_subprocess_exec(
-            "git", *args,
-            stdout=_aio.subprocess.PIPE,
-            stderr=_aio.subprocess.PIPE,
-            cwd=str(_ROOT),
-        )
-        stdout, stderr = await _aio.wait_for(proc.communicate(), timeout=15)
-        out = (stdout or b"").decode().strip()
-        err = (stderr or b"").decode().strip()
-        return proc.returncode == 0, out or err
-    except Exception as exc:
-        return False, str(exc)
-
-
-async def _git_current_branch() -> str | None:
-    """Return the current branch name, or None if not in a git repo."""
-    ok, out = await _git_run("rev-parse", "--abbrev-ref", "HEAD")
-    return out if ok else None
-
-
-async def _git_branch_exists(name: str) -> bool:
-    ok, _ = await _git_run("rev-parse", "--verify", name)
-    return ok
-
-
 @app.post("/api/chats")
 async def create_chat():
     from server import chat_history
     session = chat_history.ChatSession.new()
-
-    # Create a git branch for this chat
-    branch_name = f"imp/{session.id}"
-    ok, out = await _git_run("checkout", "-b", branch_name)
-    if ok:
-        session.branch = branch_name
-    else:
-        print(f"[chat] branch create failed: {out}", file=sys.stderr)
-
     chat_history.save_session(session)
-    return {"id": session.id, "title": session.title, "branch": session.branch}
+    return {"id": session.id, "title": session.title}
 
 
 @app.post("/api/chat/new-with-context")
@@ -372,13 +334,6 @@ async def new_chat_with_context(request: Request):
 
     # Create session
     session = chat_history.ChatSession.new()
-
-    # Create a git branch for this chat
-    branch_name = f"imp/{session.id}"
-    ok, out = await _git_run("checkout", "-b", branch_name)
-    if ok:
-        session.branch = branch_name
-
     session.append_turn("user", context_msg)
     session.append_turn("assistant",
         f"I have {len(loaded_files)} file(s) loaded: {file_list}.\n\n"
@@ -389,7 +344,7 @@ async def new_chat_with_context(request: Request):
     session.title_source = "agent"
     chat_history.save_session(session)
 
-    return {"id": session.id, "title": session.title, "prompt": prompt, "branch": session.branch}
+    return {"id": session.id, "title": session.title, "prompt": prompt}
 
 
 @app.get("/api/chats/{chat_id}")
@@ -404,96 +359,60 @@ async def get_chat(chat_id: str):
 @app.delete("/api/chats/{chat_id}")
 async def delete_chat(chat_id: str):
     from server import chat_history
-
-    # Clean up branch if it exists
-    session = chat_history.load_session(chat_id)
-    if session and session.branch:
-        # Switch to main first if we're on this branch
-        cur = await _git_current_branch()
-        if cur == session.branch:
-            await _git_run("checkout", "main")
-        # Delete the branch
-        await _git_run("branch", "-D", session.branch)
-
     ok = chat_history.delete_session(chat_id)
     return {"deleted": ok}
 
 
-@app.post("/api/chats/{chat_id}/merge")
-async def merge_chat_branch(chat_id: str):
-    """Merge the chat's branch into main and delete it."""
+@app.post("/api/chats/{chat_id}/create-issue")
+async def create_issue_from_chat(chat_id: str):
+    """Create a GitHub issue from a chat's conversation."""
+    import asyncio as _aio
     from server import chat_history
+
     session = chat_history.load_session(chat_id)
     if session is None:
         return Response("chat not found", status_code=404)
-    if not session.branch:
-        return {"error": "no branch", "merged": False}
 
-    branch = session.branch
+    title = session.title or "Chat notes"
 
-    # Check branch exists
-    if not await _git_branch_exists(branch):
-        session.branch = None
-        chat_history.save_session(session)
-        return {"error": "branch not found", "merged": False}
+    # Build body from turns (compact summary)
+    lines = []
+    for t in session.turns:
+        if not t.content.strip():
+            continue
+        label = "**User:**" if t.role == "user" else "**Agent:**"
+        # Strip HTML tool blocks, keep text
+        text = t.content.strip()
+        if len(text) > 500:
+            text = text[:500] + "..."
+        lines.append(f"{label} {text}")
+    body = "\n\n".join(lines[:20])  # cap at 20 turns
+    if len(session.turns) > 20:
+        body += f"\n\n*({len(session.turns) - 20} more turns omitted)*"
 
-    # Switch to main
-    ok, out = await _git_run("checkout", "main")
-    if not ok:
-        return {"error": f"checkout main failed: {out}", "merged": False}
+    # Read repo from config
+    cfg = _load_imp_config()
+    repo = cfg.get("repo", "")
+    if not repo:
+        return {"error": "no repo configured in .imp/config.json"}
 
-    # Merge
-    ok, out = await _git_run("merge", branch, "--no-edit")
-    if not ok:
-        # Abort the merge on conflict
-        await _git_run("merge", "--abort")
-        return {"error": f"merge failed: {out}", "merged": False}
-
-    # Delete branch
-    await _git_run("branch", "-d", branch)
-
-    # Clear branch from session
-    session.branch = None
-    chat_history.save_session(session)
-
-    return {"merged": True, "branch": branch}
-
-
-@app.post("/api/chats/{chat_id}/discard")
-async def discard_chat_branch(chat_id: str):
-    """Delete the chat's branch without merging."""
-    from server import chat_history
-    session = chat_history.load_session(chat_id)
-    if session is None:
-        return Response("chat not found", status_code=404)
-    if not session.branch:
-        return {"error": "no branch", "discarded": False}
-
-    branch = session.branch
-
-    # Switch to main if on this branch
-    cur = await _git_current_branch()
-    if cur == branch:
-        ok, out = await _git_run("checkout", "main")
-        if not ok:
-            return {"error": f"checkout main failed: {out}", "discarded": False}
-
-    # Force-delete branch
-    await _git_run("branch", "-D", branch)
-
-    # Clear branch from session
-    session.branch = None
-    chat_history.save_session(session)
-
-    return {"discarded": True, "branch": branch}
-
-
-
-@app.get("/api/git/branch")
-async def git_current_branch():
-    """Return the current git branch."""
-    branch = await _git_current_branch()
-    return {"branch": branch}
+    try:
+        proc = await _aio.create_subprocess_exec(
+            "gh", "issue", "create",
+            "--repo", repo,
+            "--title", title,
+            "--body", body[:65000],
+            stdout=_aio.subprocess.PIPE,
+            stderr=_aio.subprocess.PIPE,
+            cwd=str(_ROOT),
+        )
+        stdout, stderr = await _aio.wait_for(proc.communicate(), timeout=15)
+        url = stdout.decode().strip()
+        if proc.returncode == 0 and url:
+            return {"url": url}
+        return {"error": stderr.decode().strip() or "gh issue create failed"}
+    except Exception as exc:
+        return {"error": str(exc)}
 
 
 @app.get("/api/chats/{chat_id}/artifacts")

--- a/static/imp-chat.js
+++ b/static/imp-chat.js
@@ -346,10 +346,9 @@ async function loadChats() {
       const el = document.createElement('div');
       el.className = `chat-item${c.id === currentChatId ? ' active' : ''}`;
       const dateStr = c.created_at ? new Date(c.created_at).toLocaleString(undefined, {month:'short', day:'numeric', hour:'2-digit', minute:'2-digit'}) : '';
-      const branchDot = c.branch ? '<span class="branch-dot" title="' + c.branch + '">\u2387</span>' : '';
       const safeTitle = (c.title || 'New chat').replace(/'/g, "\\'").replace(/"/g, '&quot;');
-      const pBtn = c.turn_count > 0 ? `<button class="chat-p-btn" onclick="promptFromChat(event, '${c.id}', '${safeTitle}')" title="Create workflow from this chat">P</button>` : '';
-      el.innerHTML = `<div class="chat-title">${branchDot}${c.title || 'New chat'}</div><div class="chat-date">${dateStr}${pBtn}</div>`;
+      const pBtn = c.turn_count > 0 ? `<button class="chat-p-btn" onclick="promptFromChat(event, '${c.id}', '${safeTitle}')" title="Create tool or workflow from this chat">P</button>` : '';
+      el.innerHTML = `<div class="chat-title">${c.title || 'New chat'}</div><div class="chat-date">${dateStr}${pBtn}</div>`;
       el.onclick = () => loadChat(c.id, i === 0);
       list.appendChild(el);
     });
@@ -422,11 +421,7 @@ async function loadChat(id, isActive) {
     msgs.innerHTML = '';
     const dateStr = chat.created_at ? new Date(chat.created_at).toLocaleString() : '';
     const title = chat.title || 'Chat';
-    let headerHtml = `<div style="text-align:center;padding:16px 0 8px;"><strong>${title}</strong><br><span style="font-size:11px;color:var(--muted);">${dateStr}</span></div>`;
-    if (chat.branch) {
-      headerHtml += `<div class="branch-banner"><span class="branch-label">\u2387 ${chat.branch}</span><button class="wf-start" onclick="mergeBranch()">Merge</button><button class="wf-btn" style="color:#da3633;border-color:#da3633;" onclick="discardBranch()">Discard</button></div>`;
-    }
-    msgs.innerHTML = headerHtml;
+    msgs.innerHTML = `<div style="text-align:center;padding:16px 0 8px;"><strong>${title}</strong><br><span style="font-size:11px;color:var(--muted);">${dateStr}</span></div>`;
     (chat.turns || []).forEach(t => {
       const role = t.role === 'user' ? 'user' : 'agent';
       const content = role === 'agent' ? renderTurnFull(t) : t.content;
@@ -454,18 +449,19 @@ async function newChat() {
 
 async function deleteChat() {
   if (!currentChatId) return;
-  // Check if chat has a branch — offer merge/discard
   try {
     const res = await fetch(`${API}/api/chats/${currentChatId}`);
     const chat = await res.json();
-    if (chat.branch) {
-      const choice = prompt('This chat has branch "' + chat.branch + '".\nType "merge" to merge into main, or "discard" to delete without merging.\nLeave empty to cancel.');
+    const hasTurns = (chat.turns || []).length > 0;
+    if (hasTurns) {
+      const choice = prompt('Delete chat "' + (chat.title || 'Untitled') + '"?\n\nType "issue" to create a GitHub issue from this chat first.\nType "delete" to delete without saving.\nLeave empty to cancel.');
       if (!choice) return;
-      if (choice.toLowerCase() === 'merge') {
-        await fetch(`${API}/api/chats/${currentChatId}/merge`, { method: 'POST' });
-      } else if (choice.toLowerCase() === 'discard') {
-        await fetch(`${API}/api/chats/${currentChatId}/discard`, { method: 'POST' });
-      } else { return; }
+      if (choice.toLowerCase() === 'issue') {
+        const r = await fetch(`${API}/api/chats/${currentChatId}/create-issue`, { method: 'POST' });
+        const data = await r.json();
+        if (data.url) alert('Issue created: ' + data.url);
+        else if (data.error) { alert('Issue creation failed: ' + data.error); return; }
+      } else if (choice.toLowerCase() !== 'delete') { return; }
     } else {
       if (!confirm('Delete this chat?')) return;
     }
@@ -476,39 +472,11 @@ async function deleteChat() {
   } catch (e) { console.error('deleteChat failed:', e); }
 }
 
-async function mergeBranch() {
-  if (!currentChatId) return;
-  if (!confirm('Merge this branch into main?')) return;
-  try {
-    const res = await fetch(`${API}/api/chats/${currentChatId}/merge`, { method: 'POST' });
-    const data = await res.json();
-    if (data.merged) {
-      loadChat(currentChatId, true);
-    } else {
-      alert('Merge failed: ' + (data.error || 'unknown error'));
-    }
-  } catch (e) { alert('Merge failed: ' + e); }
-}
-
-async function discardBranch() {
-  if (!currentChatId) return;
-  if (!confirm('Discard this branch? All uncommitted changes will be lost.')) return;
-  try {
-    const res = await fetch(`${API}/api/chats/${currentChatId}/discard`, { method: 'POST' });
-    const data = await res.json();
-    if (data.discarded) {
-      loadChat(currentChatId, true);
-    } else {
-      alert('Discard failed: ' + (data.error || 'unknown error'));
-    }
-  } catch (e) { alert('Discard failed: ' + e); }
-}
-
 function promptFromChat(ev, chatId, chatTitle) {
-  // Open a new chat with instructions to create a workflow from this chat's conversation
   ev.stopPropagation();
-  const presetText = 'Review the conversation in chat "' + chatTitle + '" (id: ' + chatId + ') and create a reusable workflow from it. Extract the key steps, identify which tools were used, and create appropriate workflow step files under workflows/. If any custom tools are needed, create those too under tools/.';
-  openChatWithContext([], '', presetText, null, 'Workflow from: ' + chatTitle);
+  const chatFile = '.imp/chats/' + chatId + '/chat.json';
+  const presetText = 'Review the attached chat and create a reusable tool or workflow from it. Use make_tool.py or make_workflow.py to finalize.';
+  openChatWithContext([chatFile], '', presetText, null, 'Productize: ' + chatTitle);
 }
 
 async function openChatWithContext(files, instructions, userPrompt, sourceLock, title) {

--- a/static/imp-chat.js
+++ b/static/imp-chat.js
@@ -8,6 +8,10 @@ function renderDiff(text) {
   var lines = text.split('\n');
   var rows = '';
   var oldN = 0, newN = 0;
+  // Detect new-file diffs (all content lines are +, no - lines)
+  var isNewFile = lines.some(function(l) { return l.startsWith('+'); }) &&
+                  !lines.some(function(l) { return l.startsWith('-'); });
+  var cols = isNewFile ? 2 : 3; // single line-number col for new files
   for (var i = 0; i < lines.length; i++) {
     var line = lines[i];
     var bg, sign, lOld, lNew, content;
@@ -16,7 +20,7 @@ function renderDiff(text) {
       if (m) { oldN = parseInt(m[1]) - 1; }
       m = line.match(/\+(\d+)/);
       if (m) { newN = parseInt(m[1]) - 1; }
-      rows += '<tr style="background:#1e3a5f;"><td colspan="3" style="padding:2px 8px;font-size:10px;color:#58a6ff;font-family:monospace;">' + line + '</td></tr>';
+      rows += '<tr style="background:#1e3a5f;"><td colspan="' + cols + '" style="padding:2px 8px;font-size:10px;color:#58a6ff;font-family:monospace;">' + (isNewFile ? 'new file' : line) + '</td></tr>';
       continue;
     }
     if (line.startsWith('-')) {
@@ -41,10 +45,16 @@ function renderDiff(text) {
       lNew = newN;
       content = line.startsWith(' ') ? line.substring(1) : line;
     }
-    rows += '<tr style="background:' + bg + ';">' +
-      '<td style="padding:0 6px;font-size:10px;color:var(--muted);text-align:right;user-select:none;min-width:28px;font-family:monospace;">' + lOld + '</td>' +
-      '<td style="padding:0 6px;font-size:10px;color:var(--muted);text-align:right;user-select:none;min-width:28px;font-family:monospace;">' + lNew + '</td>' +
-      '<td style="padding:0 4px;font-family:monospace;font-size:11px;white-space:pre-wrap;">' + sign + content + '</td></tr>';
+    if (isNewFile) {
+      rows += '<tr style="background:' + bg + ';">' +
+        '<td style="padding:0 6px;font-size:10px;color:var(--muted);text-align:right;user-select:none;min-width:28px;font-family:monospace;">' + lNew + '</td>' +
+        '<td style="padding:0 4px;font-family:monospace;font-size:11px;white-space:pre-wrap;">' + content + '</td></tr>';
+    } else {
+      rows += '<tr style="background:' + bg + ';">' +
+        '<td style="padding:0 6px;font-size:10px;color:var(--muted);text-align:right;user-select:none;min-width:28px;font-family:monospace;">' + lOld + '</td>' +
+        '<td style="padding:0 6px;font-size:10px;color:var(--muted);text-align:right;user-select:none;min-width:28px;font-family:monospace;">' + lNew + '</td>' +
+        '<td style="padding:0 4px;font-family:monospace;font-size:11px;white-space:pre-wrap;">' + sign + content + '</td></tr>';
+    }
   }
   return '<table style="width:100%;border-collapse:collapse;border-spacing:0;">' + rows + '</table>';
 }

--- a/static/imp.css
+++ b/static/imp.css
@@ -269,12 +269,7 @@ body { font-family:-apple-system,BlinkMacSystemFont,"Segoe UI",Roboto,sans-serif
 #tools-tab { flex:1; overflow:hidden; }
 #tools-editor { flex:1; overflow-y:auto; padding:16px 24px; }
 
-/* --- branch banner --- */
-.branch-banner { display:flex; align-items:center; gap:8px; padding:6px 16px;
-  background:#0d1117; border:1px solid #30363d; border-radius:6px;
-  margin:0 24px 12px; font-size:12px; }
-.branch-label { flex:1; color:var(--muted); font-family:"SF Mono",Consolas,monospace; font-size:11px; }
-.branch-dot { color:var(--accent); margin-right:4px; font-size:14px; }
+/* --- chat [P] button --- */
 .chat-p-btn { float:right; background:none; border:1px solid var(--border); color:var(--muted);
   border-radius:3px; font-size:10px; font-weight:700; padding:0 4px; cursor:pointer;
   line-height:16px; font-family:"SF Mono",Consolas,monospace; }

--- a/tools/imp/README.md
+++ b/tools/imp/README.md
@@ -8,6 +8,8 @@ Local tools for managing the Imp project workspace.
 |---|---|---|
 | `clean_chats.py` | Delete chat history and execution logs | `--include-logs`, `--dry-run` |
 | `list_tools.py` | List all available tool scripts | `--group`, `--verbose` |
+| `make_tool.py` | Create GitHub issue + PR for a new tool | `--group`, `--name`, `--title` |
+| `make_workflow.py` | Create GitHub issue + PR for a new workflow | `--name`, `--title` |
 
 ## Usage
 
@@ -32,4 +34,10 @@ python tools/imp/list_tools.py --group github
 
 # List all tools with descriptions
 python tools/imp/list_tools.py --verbose
+
+# Create a tool (after writing the .py file)
+python tools/imp/make_tool.py --group github --name my_tool --title "Add my_tool"
+
+# Create a workflow (after writing step files)
+python tools/imp/make_workflow.py --name daily_report --title "Add daily report workflow"
 ```

--- a/tools/imp/make_tool.py
+++ b/tools/imp/make_tool.py
@@ -1,0 +1,147 @@
+#!/usr/bin/env python3
+"""Create a GitHub issue and PR for a new Imp tool.
+
+Inputs:
+  --group: str — tool group folder (e.g. "github", "render", "imp")
+  --name: str — tool script name without .py (e.g. "deploy_checker")
+  --title: str — human-readable title for the issue and PR
+  --description: str — extended description (optional)
+
+Process:
+  1. Verifies tools/<group>/<name>.py exists
+  2. Creates branch imp/tool-<name>
+  3. Commits all changes under tools/<group>/
+  4. Pushes and creates GitHub issue + PR
+  5. Switches back to main
+
+Output: Prints issue URL and PR URL."""
+
+import argparse
+import json
+import re
+import subprocess
+import sys
+from pathlib import Path
+
+ROOT = Path(__file__).resolve().parent.parent.parent
+
+
+def run(cmd, **kwargs):
+    """Run a command, return CompletedProcess."""
+    return subprocess.run(cmd, capture_output=True, text=True, cwd=str(ROOT), **kwargs)
+
+
+def get_repo():
+    """Read repo from .imp/config.json, fall back to git remote."""
+    cfg = ROOT / ".imp" / "config.json"
+    if cfg.exists():
+        try:
+            data = json.loads(cfg.read_text())
+            if data.get("repo"):
+                return data["repo"]
+        except (json.JSONDecodeError, KeyError):
+            pass
+    # Fallback: parse git remote
+    result = run(["git", "remote", "get-url", "origin"])
+    if result.returncode == 0:
+        url = result.stdout.strip()
+        # https://github.com/OWNER/REPO.git or git@github.com:OWNER/REPO.git
+        m = re.search(r"github\.com[:/](.+?)(?:\.git)?$", url)
+        if m:
+            return m.group(1)
+    print("Error: could not determine repo. Set 'repo' in .imp/config.json.", file=sys.stderr)
+    sys.exit(1)
+
+
+def main():
+    parser = argparse.ArgumentParser(description="Create issue + PR for a new Imp tool")
+    parser.add_argument("--group", required=True, help="Tool group folder (e.g. github, render)")
+    parser.add_argument("--name", required=True, help="Tool name without .py (e.g. deploy_checker)")
+    parser.add_argument("--title", required=True, help="Title for the issue and PR")
+    parser.add_argument("--description", default="", help="Extended description")
+    args = parser.parse_args()
+
+    tool_path = ROOT / "tools" / args.group / f"{args.name}.py"
+    if not tool_path.exists():
+        print(f"Error: {tool_path.relative_to(ROOT)} does not exist.", file=sys.stderr)
+        print("Write the tool file first, then call make_tool.py.", file=sys.stderr)
+        return 1
+
+    # Check we're on main
+    result = run(["git", "rev-parse", "--abbrev-ref", "HEAD"])
+    if result.stdout.strip() != "main":
+        print(f"Error: must be on main branch (currently on {result.stdout.strip()}).", file=sys.stderr)
+        return 1
+
+    # Check for changes in the tool group directory
+    result = run(["git", "status", "--porcelain", "--", f"tools/{args.group}/"])
+    if not result.stdout.strip():
+        print(f"No changes detected in tools/{args.group}/.", file=sys.stderr)
+        return 1
+
+    repo = get_repo()
+    branch = f"imp/tool-{args.name}"
+    body = args.description or args.title
+
+    print(f"Creating tool PR for {args.group}/{args.name}...")
+
+    # Create branch
+    result = run(["git", "checkout", "-b", branch])
+    if result.returncode != 0:
+        print(f"Error creating branch: {result.stderr}", file=sys.stderr)
+        return 1
+
+    # Stage tool files
+    run(["git", "add", f"tools/{args.group}/"])
+
+    # Commit
+    result = run(["git", "commit", "-m", f"[TOOL] {args.title}"])
+    if result.returncode != 0:
+        print(f"Error committing: {result.stderr}", file=sys.stderr)
+        run(["git", "checkout", "main"])
+        return 1
+
+    # Push
+    result = run(["git", "push", "-u", "origin", branch])
+    if result.returncode != 0:
+        print(f"Error pushing: {result.stderr}", file=sys.stderr)
+        run(["git", "checkout", "main"])
+        return 1
+
+    # Create issue
+    result = run([
+        "gh", "issue", "create",
+        "--repo", repo,
+        "--title", f"New tool: {args.group}/{args.name}",
+        "--body", body,
+    ])
+    issue_url = result.stdout.strip()
+    issue_num = ""
+    if issue_url:
+        m = re.search(r"/(\d+)$", issue_url)
+        if m:
+            issue_num = m.group(1)
+        print(f"Issue: {issue_url}")
+
+    # Create PR
+    pr_body = f"Closes #{issue_num}\n\n{body}" if issue_num else body
+    result = run([
+        "gh", "pr", "create",
+        "--repo", repo,
+        "--title", f"[TOOL] {args.title}",
+        "--body", pr_body,
+        "--head", branch,
+        "--base", "main",
+    ])
+    if result.stdout.strip():
+        print(f"PR: {result.stdout.strip()}")
+
+    # Switch back to main
+    run(["git", "checkout", "main"])
+
+    print("Done.")
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/tools/imp/make_workflow.py
+++ b/tools/imp/make_workflow.py
@@ -1,0 +1,148 @@
+#!/usr/bin/env python3
+"""Create a GitHub issue and PR for a new Imp workflow.
+
+Inputs:
+  --name: str — workflow name (e.g. "daily_report")
+  --title: str — human-readable title for the issue and PR
+  --description: str — extended description (optional)
+
+Process:
+  1. Verifies workflows/<name>/ exists with step files
+  2. Creates branch imp/wf-<name>
+  3. Commits all changes under workflows/<name>/
+  4. Pushes and creates GitHub issue + PR
+  5. Switches back to main
+
+Output: Prints issue URL and PR URL."""
+
+import argparse
+import json
+import re
+import subprocess
+import sys
+from pathlib import Path
+
+ROOT = Path(__file__).resolve().parent.parent.parent
+
+
+def run(cmd, **kwargs):
+    """Run a command, return CompletedProcess."""
+    return subprocess.run(cmd, capture_output=True, text=True, cwd=str(ROOT), **kwargs)
+
+
+def get_repo():
+    """Read repo from .imp/config.json, fall back to git remote."""
+    cfg = ROOT / ".imp" / "config.json"
+    if cfg.exists():
+        try:
+            data = json.loads(cfg.read_text())
+            if data.get("repo"):
+                return data["repo"]
+        except (json.JSONDecodeError, KeyError):
+            pass
+    result = run(["git", "remote", "get-url", "origin"])
+    if result.returncode == 0:
+        url = result.stdout.strip()
+        m = re.search(r"github\.com[:/](.+?)(?:\.git)?$", url)
+        if m:
+            return m.group(1)
+    print("Error: could not determine repo. Set 'repo' in .imp/config.json.", file=sys.stderr)
+    sys.exit(1)
+
+
+def main():
+    parser = argparse.ArgumentParser(description="Create issue + PR for a new Imp workflow")
+    parser.add_argument("--name", required=True, help="Workflow name (e.g. daily_report)")
+    parser.add_argument("--title", required=True, help="Title for the issue and PR")
+    parser.add_argument("--description", default="", help="Extended description")
+    args = parser.parse_args()
+
+    wf_dir = ROOT / "workflows" / args.name
+    if not wf_dir.is_dir():
+        print(f"Error: workflows/{args.name}/ does not exist.", file=sys.stderr)
+        print("Write the workflow files first, then call make_workflow.py.", file=sys.stderr)
+        return 1
+
+    steps = list(wf_dir.glob("step_*.py"))
+    if not steps:
+        print(f"Error: workflows/{args.name}/ has no step files.", file=sys.stderr)
+        return 1
+
+    # Check we're on main
+    result = run(["git", "rev-parse", "--abbrev-ref", "HEAD"])
+    if result.stdout.strip() != "main":
+        print(f"Error: must be on main branch (currently on {result.stdout.strip()}).", file=sys.stderr)
+        return 1
+
+    # Check for changes
+    result = run(["git", "status", "--porcelain", "--", f"workflows/{args.name}/"])
+    if not result.stdout.strip():
+        print(f"No changes detected in workflows/{args.name}/.", file=sys.stderr)
+        return 1
+
+    repo = get_repo()
+    branch = f"imp/wf-{args.name}"
+    body = args.description or args.title
+
+    print(f"Creating workflow PR for {args.name} ({len(steps)} steps)...")
+
+    # Create branch
+    result = run(["git", "checkout", "-b", branch])
+    if result.returncode != 0:
+        print(f"Error creating branch: {result.stderr}", file=sys.stderr)
+        return 1
+
+    # Stage workflow files
+    run(["git", "add", f"workflows/{args.name}/"])
+
+    # Commit
+    result = run(["git", "commit", "-m", f"[WORKFLOW] {args.title}"])
+    if result.returncode != 0:
+        print(f"Error committing: {result.stderr}", file=sys.stderr)
+        run(["git", "checkout", "main"])
+        return 1
+
+    # Push
+    result = run(["git", "push", "-u", "origin", branch])
+    if result.returncode != 0:
+        print(f"Error pushing: {result.stderr}", file=sys.stderr)
+        run(["git", "checkout", "main"])
+        return 1
+
+    # Create issue
+    result = run([
+        "gh", "issue", "create",
+        "--repo", repo,
+        "--title", f"New workflow: {args.name}",
+        "--body", body,
+    ])
+    issue_url = result.stdout.strip()
+    issue_num = ""
+    if issue_url:
+        m = re.search(r"/(\d+)$", issue_url)
+        if m:
+            issue_num = m.group(1)
+        print(f"Issue: {issue_url}")
+
+    # Create PR
+    pr_body = f"Closes #{issue_num}\n\n{body}" if issue_num else body
+    result = run([
+        "gh", "pr", "create",
+        "--repo", repo,
+        "--title", f"[WORKFLOW] {args.title}",
+        "--body", pr_body,
+        "--head", branch,
+        "--base", "main",
+    ])
+    if result.stdout.strip():
+        print(f"PR: {result.stdout.strip()}")
+
+    # Switch back to main
+    run(["git", "checkout", "main"])
+
+    print("Done.")
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())


### PR DESCRIPTION
## Summary

Replaces the auto-branch-per-chat approach (closed PR #141) with three explicit tools:

- **`tools/imp/make_tool.py`** — Foreman writes the tool file, then calls this to create branch + commit + push + GitHub issue + PR
- **`tools/imp/make_workflow.py`** — same for workflows
- **`tools/github/solve_issues.py`** — already exists for project issues

### New UI features
- **[P] button** on sidebar chat items — attaches chat JSON, opens new chat with preset to create tool or workflow
- **Delete chat popup** — offers to create a GitHub issue from the chat before deleting (instead of the old merge/discard flow)
- **Foreman prompt** — new "Creating tools and workflows" section with step-by-step instructions

### Removed (from #141)
- Auto-branch creation on every chat
- Branch field on ChatSession
- Merge/discard/checkout endpoints and UI
- Branch banner and branch-dot indicator

Closes #153

## Test plan
- [ ] Ask Foreman to create a tool → verify it writes .py file, then calls make_tool.py, which creates branch + issue + PR
- [ ] Ask Foreman to create a workflow → same with make_workflow.py
- [ ] Click [P] on a sidebar chat → new chat opens with chat JSON loaded
- [ ] Delete a chat with turns → popup offers "issue" / "delete" / cancel
- [ ] Type "issue" → GitHub issue created with chat summary
- [ ] Verify no auto-branching on new chat creation

🤖 Generated with [Claude Code](https://claude.com/claude-code)