### PR TITLE
Keep tool/workflow files locally after creating PR (#160)

### DIFF
--- a/tools/imp/make_tool.py
+++ b/tools/imp/make_tool.py
@@ -136,8 +136,11 @@ def main():
     if result.stdout.strip():
         print(f"PR: {result.stdout.strip()}")
 
-    # Switch back to main
+    # Switch back to main, restore files so the tool stays locally available
+    tool_dir = f"tools/{args.group}/"
     run(["git", "checkout", "main"])
+    run(["git", "checkout", branch, "--", tool_dir])
+    run(["git", "reset", "HEAD", tool_dir])
 
     print("Done.")
     return 0

--- a/tools/imp/make_workflow.py
+++ b/tools/imp/make_workflow.py
@@ -137,8 +137,11 @@ def main():
     if result.stdout.strip():
         print(f"PR: {result.stdout.strip()}")
 
-    # Switch back to main
+    # Switch back to main, restore files so the workflow stays locally available
+    wf_dir = f"workflows/{args.name}/"
     run(["git", "checkout", "main"])
+    run(["git", "checkout", branch, "--", wf_dir])
+    run(["git", "reset", "HEAD", wf_dir])
 
     print("Done.")
     return 0


### PR DESCRIPTION
## Summary
After `make_tool.py` / `make_workflow.py` switches back to main, restores the files from the branch so they stay as untracked files on disk.

- Tool/workflow works locally immediately after creation
- PR handles GitHub sync for other installations
- If merged: everyone gets it. If not: stays local only.

Closes #160

## Test plan
- [ ] Create a tool via make_tool.py
- [ ] Verify the .py file still exists on disk after the script finishes
- [ ] Verify you're on main, not the branch
- [ ] Verify the tool shows up in the Tools tab

🤖 Generated with [Claude Code](https://claude.com/claude-code)