### PR TITLE
Show tool name + args when unfolded, fix clean_chats (#162, #163)

### DIFF
--- a/static/imp-chat.js
+++ b/static/imp-chat.js
@@ -224,9 +224,10 @@ function connectWs() {
         const desc = entry ? entry.desc : msg.name;
         const tag = entry ? entry.tag : '';
         const formattedOutput = msg.output ? formatStepOutput(msg.output) : '<pre>(no output)</pre>';
+        const argsLine = entry && entry.args ? `<div style="padding:4px 10px;font-size:11px;color:var(--muted);font-family:monospace;border-bottom:1px solid var(--border);">${msg.name}(${formatArgs(entry.args)})</div>` : '';
         if (tag) {
           const oldBlock = `<details class="tool-block running ${tag}"><summary>⏳ ${desc}...</summary><pre>Running...</pre></details>`;
-          const newBlock = `<details class="tool-block ${msg.status} ${tag}"><summary>${icon} ${desc}${dur}</summary><div class="wf-step-output">${formattedOutput}</div></details>`;
+          const newBlock = `<details class="tool-block ${msg.status} ${tag}"><summary>${icon} ${desc}${dur}</summary>${argsLine}<div class="wf-step-output">${formattedOutput}</div></details>`;
           agentText = agentText.replace(oldBlock, newBlock);
         }
         renderAgentBody();
@@ -262,6 +263,7 @@ function connectWs() {
         setWorking(false);
         setStatus('');
         scrollBottom();
+        loadChats();
         if (_chatSourceLock && _chatSourceLock.chatId === currentChatId) {
           unlockChatSource();
         }

--- a/tools/imp/clean_chats.py
+++ b/tools/imp/clean_chats.py
@@ -17,11 +17,11 @@ CHAT_DIR = Path(".imp/chats")
 LOGS_DIR = Path("public/logs")
 
 
-def _collect_files(directory: Path) -> list[Path]:
-    """Return all files in *directory* (non-recursive)."""
+def _collect_entries(directory: Path) -> list[Path]:
+    """Return all files and subdirectories in *directory*."""
     if not directory.is_dir():
         return []
-    return sorted(f for f in directory.iterdir() if f.is_file())
+    return sorted(directory.iterdir())
 
 
 def main() -> int:
@@ -38,29 +38,33 @@ def main() -> int:
     )
     args = parser.parse_args()
 
-    targets: dict[str, list[Path]] = {"chats": _collect_files(CHAT_DIR)}
+    targets: dict[str, list[Path]] = {"chats": _collect_entries(CHAT_DIR)}
     if args.include_logs:
-        targets["logs"] = _collect_files(LOGS_DIR)
+        targets["logs"] = _collect_entries(LOGS_DIR)
 
     total = 0
-    for label, files in targets.items():
-        if not files:
+    for label, entries in targets.items():
+        if not entries:
             print(f"{label}: nothing to clean")
             continue
 
+        import shutil
         action = "would delete" if args.dry_run else "deleted"
-        for f in files:
+        for entry in entries:
             if not args.dry_run:
-                f.unlink()
-            print(f"  {action}: {f}")
-        print(f"{label}: {action} {len(files)} file(s)")
-        total += len(files)
+                if entry.is_dir():
+                    shutil.rmtree(entry)
+                else:
+                    entry.unlink()
+            print(f"  {action}: {entry}")
+        print(f"{label}: {action} {len(entries)} item(s)")
+        total += len(entries)
 
     if total == 0:
         print("Nothing to clean up.")
     else:
         verb = "Would delete" if args.dry_run else "Deleted"
-        print(f"\n{verb} {total} file(s) total.")
+        print(f"\n{verb} {total} item(s) total.")
 
     return 0
 


### PR DESCRIPTION
## Summary
- **Tool blocks** now show the actual tool name and parameters in monospace when expanded (e.g. `Bash(command="python tools/imp/clean_chats.py")`)
- **clean_chats.py** now handles chat subdirectories (`.imp/chats/<id>/`) instead of only looking for flat files

Closes #162, closes #163

## Test plan
- [x] Send a message in chat, expand a tool block — should show tool name + args
- [x] Run `python tools/imp/clean_chats.py --dry-run` — should list chat directories
- [x] Run `python tools/imp/clean_chats.py` — should actually delete them

🤖 Generated with [Claude Code](https://claude.com/claude-code)