### PR TITLE
Split make_tool/make_workflow from git publish (#169)

### DIFF
--- a/server/foreman_prompt.md
+++ b/server/foreman_prompt.md
@@ -52,21 +52,29 @@ Queue API at `{{IMP_BASE_URL}}`:
 
 When the user asks to "turn this into a tool" or "make a tool for this":
 
-1. **Write the tool file** using the Write tool at `tools/<group>/<name>.py`.
+1. **Write the tool file** using Write at `tools/<group>/<name>.py`.
    Follow existing conventions: shebang, docstring (Inputs/Process/Output), argparse, exit codes.
-2. **Publish it** by running:
-   `python tools/imp/make_tool.py --group <group> --name <name> --title "<title>"`
-   This creates a branch, commits, pushes, and opens a GitHub issue + PR automatically.
+2. **Register it** locally: `python tools/imp/make_tool.py --group <group> --name <name>`
+   This validates the file and reloads the tool list so it's immediately available.
 
 When the user asks to "turn this into a workflow":
 
 1. **Write the workflow files** using Write:
-   - `workflows/<name>/README.md` — description of what the workflow does
+   - `workflows/<name>/README.md` — description
    - `workflows/<name>/step_1_<desc>.py` — each step has `def run(context): ...` returning `{"ok": bool, "output": str}`
-2. **Publish it** by running:
-   `python tools/imp/make_workflow.py --name <name> --title "<title>"`
+2. **Register it** locally: `python tools/imp/make_workflow.py --name <name>`
 
-Do NOT manually run git commands for this — use the make_tool/make_workflow scripts.
+## Publishing to GitHub
+
+To push a local tool or workflow to GitHub as an issue + PR:
+
+`python tools/imp/publish_pr.py --path <dir> --title "..."`
+
+Examples:
+- `python tools/imp/publish_pr.py --path tools/imp/ --title "Add queue test tool"`
+- `python tools/imp/publish_pr.py --path workflows/daily_report/ --title "Add daily report workflow"`
+
+Only publish when the user asks. Tools and workflows work locally without publishing.
 
 ## Bash fallback
 

--- a/tools/imp/make_tool.py
+++ b/tools/imp/make_tool.py
@@ -1,24 +1,18 @@
 #!/usr/bin/env python3
-"""Create a GitHub issue and PR for a new Imp tool.
+"""Register a new tool locally.
 
 Inputs:
   --group: str — tool group folder (e.g. "github", "render", "imp")
   --name: str — tool script name without .py (e.g. "deploy_checker")
-  --title: str — human-readable title for the issue and PR
-  --description: str — extended description (optional)
 
 Process:
-  1. Verifies tools/<group>/<name>.py exists
-  2. Creates branch imp/tool-<name>
-  3. Commits all changes under tools/<group>/
-  4. Pushes and creates GitHub issue + PR
-  5. Switches back to main
+  1. Verifies tools/<group>/<name>.py exists and is valid Python
+  2. Reloads the Foreman tool list so the new tool is immediately available
 
-Output: Prints issue URL and PR URL."""
+Output: Prints confirmation. Use publish_pr.py to push to GitHub."""
 
 import argparse
-import json
-import re
+import ast
 import subprocess
 import sys
 from pathlib import Path
@@ -26,123 +20,38 @@ from pathlib import Path
 ROOT = Path(__file__).resolve().parent.parent.parent
 
 
-def run(cmd, **kwargs):
-    """Run a command, return CompletedProcess."""
-    return subprocess.run(cmd, capture_output=True, text=True, cwd=str(ROOT), **kwargs)
-
-
-def get_repo():
-    """Read repo from .imp/config.json, fall back to git remote."""
-    cfg = ROOT / ".imp" / "config.json"
-    if cfg.exists():
-        try:
-            data = json.loads(cfg.read_text())
-            if data.get("repo"):
-                return data["repo"]
-        except (json.JSONDecodeError, KeyError):
-            pass
-    # Fallback: parse git remote
-    result = run(["git", "remote", "get-url", "origin"])
-    if result.returncode == 0:
-        url = result.stdout.strip()
-        # https://github.com/OWNER/REPO.git or git@github.com:OWNER/REPO.git
-        m = re.search(r"github\.com[:/](.+?)(?:\.git)?$", url)
-        if m:
-            return m.group(1)
-    print("Error: could not determine repo. Set 'repo' in .imp/config.json.", file=sys.stderr)
-    sys.exit(1)
-
-
 def main():
-    parser = argparse.ArgumentParser(description="Create issue + PR for a new Imp tool")
+    parser = argparse.ArgumentParser(description="Register a new tool locally")
     parser.add_argument("--group", required=True, help="Tool group folder (e.g. github, render)")
     parser.add_argument("--name", required=True, help="Tool name without .py (e.g. deploy_checker)")
-    parser.add_argument("--title", required=True, help="Title for the issue and PR")
-    parser.add_argument("--description", default="", help="Extended description")
     args = parser.parse_args()
 
     tool_path = ROOT / "tools" / args.group / f"{args.name}.py"
     if not tool_path.exists():
         print(f"Error: {tool_path.relative_to(ROOT)} does not exist.", file=sys.stderr)
-        print("Write the tool file first, then call make_tool.py.", file=sys.stderr)
         return 1
 
-    # Check we're on main
-    result = run(["git", "rev-parse", "--abbrev-ref", "HEAD"])
-    if result.stdout.strip() != "main":
-        print(f"Error: must be on main branch (currently on {result.stdout.strip()}).", file=sys.stderr)
+    # Validate syntax
+    source = tool_path.read_text()
+    try:
+        ast.parse(source)
+    except SyntaxError as e:
+        print(f"Syntax error in {tool_path.relative_to(ROOT)}: {e}", file=sys.stderr)
         return 1
 
-    # Check for changes in the tool group directory
-    result = run(["git", "status", "--porcelain", "--", f"tools/{args.group}/"])
-    if not result.stdout.strip():
-        print(f"No changes detected in tools/{args.group}/.", file=sys.stderr)
-        return 1
+    # Extract docstring
+    doc = ast.get_docstring(ast.parse(source)) or ""
+    first_line = doc.split("\n")[0] if doc else "(no description)"
 
-    repo = get_repo()
-    branch = f"imp/tool-{args.name}"
-    body = args.description or args.title
+    # Reload Foreman prompt
+    subprocess.run(
+        [sys.executable, "tools/imp/reload_tools.py"],
+        capture_output=True, cwd=str(ROOT),
+    )
 
-    print(f"Creating tool PR for {args.group}/{args.name}...")
-
-    # Create branch
-    result = run(["git", "checkout", "-b", branch])
-    if result.returncode != 0:
-        print(f"Error creating branch: {result.stderr}", file=sys.stderr)
-        return 1
-
-    # Stage tool files
-    run(["git", "add", f"tools/{args.group}/"])
-
-    # Commit
-    result = run(["git", "commit", "-m", f"[TOOL] {args.title}"])
-    if result.returncode != 0:
-        print(f"Error committing: {result.stderr}", file=sys.stderr)
-        run(["git", "checkout", "main"])
-        return 1
-
-    # Push
-    result = run(["git", "push", "-u", "origin", branch])
-    if result.returncode != 0:
-        print(f"Error pushing: {result.stderr}", file=sys.stderr)
-        run(["git", "checkout", "main"])
-        return 1
-
-    # Create issue
-    result = run([
-        "gh", "issue", "create",
-        "--repo", repo,
-        "--title", f"New tool: {args.group}/{args.name}",
-        "--body", body,
-    ])
-    issue_url = result.stdout.strip()
-    issue_num = ""
-    if issue_url:
-        m = re.search(r"/(\d+)$", issue_url)
-        if m:
-            issue_num = m.group(1)
-        print(f"Issue: {issue_url}")
-
-    # Create PR
-    pr_body = f"Closes #{issue_num}\n\n{body}" if issue_num else body
-    result = run([
-        "gh", "pr", "create",
-        "--repo", repo,
-        "--title", f"[TOOL] {args.title}",
-        "--body", pr_body,
-        "--head", branch,
-        "--base", "main",
-    ])
-    if result.stdout.strip():
-        print(f"PR: {result.stdout.strip()}")
-
-    # Switch back to main, restore files so the tool stays locally available
-    tool_dir = f"tools/{args.group}/"
-    run(["git", "checkout", "main"])
-    run(["git", "checkout", branch, "--", tool_dir])
-    run(["git", "reset", "HEAD", tool_dir])
-
-    print("Done.")
+    print(f"Tool registered: tools/{args.group}/{args.name}.py")
+    print(f"Description: {first_line}")
+    print(f"\nTo publish to GitHub: python tools/imp/publish_pr.py --path tools/{args.group}/ --title \"...\"")
     return 0
 
 

--- a/tools/imp/make_workflow.py
+++ b/tools/imp/make_workflow.py
@@ -1,23 +1,18 @@
 #!/usr/bin/env python3
-"""Create a GitHub issue and PR for a new Imp workflow.
+"""Register a new workflow locally.
 
 Inputs:
   --name: str — workflow name (e.g. "daily_report")
-  --title: str — human-readable title for the issue and PR
-  --description: str — extended description (optional)
 
 Process:
   1. Verifies workflows/<name>/ exists with step files
-  2. Creates branch imp/wf-<name>
-  3. Commits all changes under workflows/<name>/
-  4. Pushes and creates GitHub issue + PR
-  5. Switches back to main
+  2. Validates each step file has a run(context) function
+  3. Reloads the Foreman tool list
 
-Output: Prints issue URL and PR URL."""
+Output: Prints confirmation. Use publish_pr.py to push to GitHub."""
 
 import argparse
-import json
-import re
+import ast
 import subprocess
 import sys
 from pathlib import Path
@@ -25,125 +20,47 @@ from pathlib import Path
 ROOT = Path(__file__).resolve().parent.parent.parent
 
 
-def run(cmd, **kwargs):
-    """Run a command, return CompletedProcess."""
-    return subprocess.run(cmd, capture_output=True, text=True, cwd=str(ROOT), **kwargs)
-
-
-def get_repo():
-    """Read repo from .imp/config.json, fall back to git remote."""
-    cfg = ROOT / ".imp" / "config.json"
-    if cfg.exists():
-        try:
-            data = json.loads(cfg.read_text())
-            if data.get("repo"):
-                return data["repo"]
-        except (json.JSONDecodeError, KeyError):
-            pass
-    result = run(["git", "remote", "get-url", "origin"])
-    if result.returncode == 0:
-        url = result.stdout.strip()
-        m = re.search(r"github\.com[:/](.+?)(?:\.git)?$", url)
-        if m:
-            return m.group(1)
-    print("Error: could not determine repo. Set 'repo' in .imp/config.json.", file=sys.stderr)
-    sys.exit(1)
-
-
 def main():
-    parser = argparse.ArgumentParser(description="Create issue + PR for a new Imp workflow")
+    parser = argparse.ArgumentParser(description="Register a new workflow locally")
     parser.add_argument("--name", required=True, help="Workflow name (e.g. daily_report)")
-    parser.add_argument("--title", required=True, help="Title for the issue and PR")
-    parser.add_argument("--description", default="", help="Extended description")
     args = parser.parse_args()
 
     wf_dir = ROOT / "workflows" / args.name
     if not wf_dir.is_dir():
         print(f"Error: workflows/{args.name}/ does not exist.", file=sys.stderr)
-        print("Write the workflow files first, then call make_workflow.py.", file=sys.stderr)
         return 1
 
-    steps = list(wf_dir.glob("step_*.py"))
+    steps = sorted(wf_dir.glob("step_*.py"))
     if not steps:
         print(f"Error: workflows/{args.name}/ has no step files.", file=sys.stderr)
         return 1
 
-    # Check we're on main
-    result = run(["git", "rev-parse", "--abbrev-ref", "HEAD"])
-    if result.stdout.strip() != "main":
-        print(f"Error: must be on main branch (currently on {result.stdout.strip()}).", file=sys.stderr)
-        return 1
+    # Validate each step
+    for step in steps:
+        source = step.read_text()
+        try:
+            tree = ast.parse(source)
+        except SyntaxError as e:
+            print(f"Syntax error in {step.name}: {e}", file=sys.stderr)
+            return 1
+        has_run = any(
+            isinstance(node, ast.FunctionDef) and node.name == "run"
+            for node in ast.walk(tree)
+        )
+        if not has_run:
+            print(f"Warning: {step.name} has no run(context) function.", file=sys.stderr)
 
-    # Check for changes
-    result = run(["git", "status", "--porcelain", "--", f"workflows/{args.name}/"])
-    if not result.stdout.strip():
-        print(f"No changes detected in workflows/{args.name}/.", file=sys.stderr)
-        return 1
+    # Reload Foreman prompt
+    subprocess.run(
+        [sys.executable, "tools/imp/reload_tools.py"],
+        capture_output=True, cwd=str(ROOT),
+    )
 
-    repo = get_repo()
-    branch = f"imp/wf-{args.name}"
-    body = args.description or args.title
-
-    print(f"Creating workflow PR for {args.name} ({len(steps)} steps)...")
-
-    # Create branch
-    result = run(["git", "checkout", "-b", branch])
-    if result.returncode != 0:
-        print(f"Error creating branch: {result.stderr}", file=sys.stderr)
-        return 1
-
-    # Stage workflow files
-    run(["git", "add", f"workflows/{args.name}/"])
-
-    # Commit
-    result = run(["git", "commit", "-m", f"[WORKFLOW] {args.title}"])
-    if result.returncode != 0:
-        print(f"Error committing: {result.stderr}", file=sys.stderr)
-        run(["git", "checkout", "main"])
-        return 1
-
-    # Push
-    result = run(["git", "push", "-u", "origin", branch])
-    if result.returncode != 0:
-        print(f"Error pushing: {result.stderr}", file=sys.stderr)
-        run(["git", "checkout", "main"])
-        return 1
-
-    # Create issue
-    result = run([
-        "gh", "issue", "create",
-        "--repo", repo,
-        "--title", f"New workflow: {args.name}",
-        "--body", body,
-    ])
-    issue_url = result.stdout.strip()
-    issue_num = ""
-    if issue_url:
-        m = re.search(r"/(\d+)$", issue_url)
-        if m:
-            issue_num = m.group(1)
-        print(f"Issue: {issue_url}")
-
-    # Create PR
-    pr_body = f"Closes #{issue_num}\n\n{body}" if issue_num else body
-    result = run([
-        "gh", "pr", "create",
-        "--repo", repo,
-        "--title", f"[WORKFLOW] {args.title}",
-        "--body", pr_body,
-        "--head", branch,
-        "--base", "main",
-    ])
-    if result.stdout.strip():
-        print(f"PR: {result.stdout.strip()}")
-
-    # Switch back to main, restore files so the workflow stays locally available
-    wf_dir = f"workflows/{args.name}/"
-    run(["git", "checkout", "main"])
-    run(["git", "checkout", branch, "--", wf_dir])
-    run(["git", "reset", "HEAD", wf_dir])
-
-    print("Done.")
+    print(f"Workflow registered: workflows/{args.name}/ ({len(steps)} steps)")
+    for s in steps:
+        doc = ast.get_docstring(ast.parse(s.read_text())) or "(no description)"
+        print(f"  {s.name}: {doc.split(chr(10))[0]}")
+    print(f"\nTo publish to GitHub: python tools/imp/publish_pr.py --path workflows/{args.name}/ --title \"...\"")
     return 0
 
 

--- a/tools/imp/publish_pr.py
+++ b/tools/imp/publish_pr.py
@@ -1,0 +1,144 @@
+#!/usr/bin/env python3
+"""Publish a local tool or workflow to GitHub as an issue + PR.
+
+Inputs:
+  --path: str — path to tool group dir (e.g. "tools/imp/") or workflow dir (e.g. "workflows/daily_report/")
+  --title: str — title for the issue and PR
+  --description: str — extended description (optional)
+
+Process:
+  1. Detects uncommitted changes in the given path
+  2. Creates a branch, commits, pushes
+  3. Creates a GitHub issue and PR
+  4. Switches back to main, keeps files locally
+
+Output: Prints issue URL and PR URL."""
+
+import argparse
+import json
+import re
+import subprocess
+import sys
+from pathlib import Path
+
+ROOT = Path(__file__).resolve().parent.parent.parent
+
+
+def run(cmd, **kwargs):
+    """Run a command, return CompletedProcess."""
+    return subprocess.run(cmd, capture_output=True, text=True, cwd=str(ROOT), **kwargs)
+
+
+def get_repo():
+    """Read repo from .imp/config.json, fall back to git remote."""
+    cfg = ROOT / ".imp" / "config.json"
+    if cfg.exists():
+        try:
+            data = json.loads(cfg.read_text())
+            if data.get("repo"):
+                return data["repo"]
+        except (json.JSONDecodeError, KeyError):
+            pass
+    result = run(["git", "remote", "get-url", "origin"])
+    if result.returncode == 0:
+        url = result.stdout.strip()
+        m = re.search(r"github\.com[:/](.+?)(?:\.git)?$", url)
+        if m:
+            return m.group(1)
+    print("Error: could not determine repo. Set 'repo' in .imp/config.json.", file=sys.stderr)
+    sys.exit(1)
+
+
+def main():
+    parser = argparse.ArgumentParser(description="Publish local tool/workflow as GitHub issue + PR")
+    parser.add_argument("--path", required=True, help="Path to publish (e.g. tools/imp/ or workflows/daily_report/)")
+    parser.add_argument("--title", required=True, help="Title for the issue and PR")
+    parser.add_argument("--description", default="", help="Extended description")
+    args = parser.parse_args()
+
+    target = args.path.rstrip("/")
+    full = ROOT / target
+    if not full.exists():
+        print(f"Error: {target} does not exist.", file=sys.stderr)
+        return 1
+
+    # Check we're on main
+    result = run(["git", "rev-parse", "--abbrev-ref", "HEAD"])
+    if result.stdout.strip() != "main":
+        print(f"Error: must be on main branch (currently on {result.stdout.strip()}).", file=sys.stderr)
+        return 1
+
+    # Check for changes
+    result = run(["git", "status", "--porcelain", "--", target])
+    if not result.stdout.strip():
+        print(f"No uncommitted changes in {target}.", file=sys.stderr)
+        return 1
+
+    repo = get_repo()
+    # Branch name from path: tools/imp/foo -> imp/pub-imp-foo, workflows/bar -> imp/pub-bar
+    slug = target.replace("/", "-").replace("tools-", "").replace("workflows-", "wf-")
+    branch = f"imp/pub-{slug}"
+    body = args.description or args.title
+
+    print(f"Publishing {target}...")
+
+    # Create branch
+    result = run(["git", "checkout", "-b", branch])
+    if result.returncode != 0:
+        print(f"Error creating branch: {result.stderr}", file=sys.stderr)
+        return 1
+
+    # Stage and commit
+    run(["git", "add", target])
+    result = run(["git", "commit", "-m", args.title])
+    if result.returncode != 0:
+        print(f"Error committing: {result.stderr}", file=sys.stderr)
+        run(["git", "checkout", "main"])
+        return 1
+
+    # Push
+    result = run(["git", "push", "-u", "origin", branch])
+    if result.returncode != 0:
+        print(f"Error pushing: {result.stderr}", file=sys.stderr)
+        run(["git", "checkout", "main"])
+        return 1
+
+    # Create issue
+    result = run([
+        "gh", "issue", "create",
+        "--repo", repo,
+        "--title", args.title,
+        "--body", body,
+    ])
+    issue_url = result.stdout.strip()
+    issue_num = ""
+    if issue_url:
+        m = re.search(r"/(\d+)$", issue_url)
+        if m:
+            issue_num = m.group(1)
+        print(f"Issue: {issue_url}")
+
+    # Create PR
+    pr_body = f"Closes #{issue_num}\n\n{body}" if issue_num else body
+    result = run([
+        "gh", "pr", "create",
+        "--repo", repo,
+        "--title", args.title,
+        "--body", pr_body,
+        "--head", branch,
+        "--base", "main",
+    ])
+    if result.stdout.strip():
+        print(f"PR: {result.stdout.strip()}")
+
+    # Switch back to main, restore files locally
+    run(["git", "checkout", "main"])
+    run(["git", "checkout", branch, "--", target])
+    run(["git", "reset", "HEAD", target])
+
+    print("Done.")
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())


### PR DESCRIPTION
## Summary

Separates local tool/workflow creation from GitHub publishing:

- **make_tool.py** — local only: validates the .py file, reloads tool list
- **make_workflow.py** — local only: validates step files, reloads tool list  
- **publish_pr.py** — NEW: takes any path, creates branch + commit + push + issue + PR, keeps files locally

Foreman prompt updated with two-step flow: "register" locally, "publish" to GitHub when ready.

Closes #169

## Test plan
- [x] Create a tool via Write + make_tool.py — should validate and reload, no git
- [x] Run publish_pr.py on the tool — should create branch, issue, PR
- [x] Verify tool still exists locally after publish
- [x] Create a workflow via Write + make_workflow.py — should validate steps
- [x] Publish workflow — same git flow

🤖 Generated with [Claude Code](https://claude.com/claude-code)