### PR TITLE
Add sync_upstream and push_fix tools for downstream projects

### DIFF
--- a/tools/imp/README.md
+++ b/tools/imp/README.md
@@ -10,6 +10,8 @@ Local tools for managing the Imp project workspace.
 | `list_tools.py` | List all available tool scripts | `--group`, `--verbose` |
 | `make_tool.py` | Create GitHub issue + PR for a new tool | `--group`, `--name`, `--title` |
 | `make_workflow.py` | Create GitHub issue + PR for a new workflow | `--name`, `--title` |
+| `sync_upstream.py` | Pull latest Imp core updates into this project | `--dry-run`, `--repo` |
+| `push_fix.py` | Push a bug fix back to the upstream Imp repo as a PR | `--files`, `--message`, `--repo` |
 
 ## Usage
 
@@ -40,4 +42,16 @@ python tools/imp/make_tool.py --group github --name my_tool --title "Add my_tool
 
 # Create a workflow (after writing step files)
 python tools/imp/make_workflow.py --name daily_report --title "Add daily report workflow"
+
+# Check what Imp updates are available (no changes applied)
+python tools/imp/sync_upstream.py --dry-run
+
+# Pull latest Imp core updates
+python tools/imp/sync_upstream.py
+
+# Push a bug fix back to the Imp repo
+python tools/imp/push_fix.py --files server/render_route.py --message "Fix WebSocket reconnect"
+
+# Push multiple files
+python tools/imp/push_fix.py --files server/render_route.py --files server/chat_ws.py --message "Fix chat reconnect"
 ```

--- a/tools/imp/push_fix.py
+++ b/tools/imp/push_fix.py
@@ -1,0 +1,141 @@
+#!/usr/bin/env python3
+"""Push a bug fix from this project back to the upstream Imp repo as a PR.
+
+Inputs:
+  --files: str (repeatable) — files to push (relative paths, e.g. "server/render_route.py").
+  --message: str — commit message / PR title.
+  --repo: str — upstream Imp repo (default: read from .imp/upstream.json, or "KKallas/Imp").
+
+Process:
+  1. Clones the upstream Imp repo to a temp directory
+  2. Copies the specified files from this project into the clone
+  3. Creates a branch, commits, and pushes
+  4. Opens a PR on the upstream repo
+
+Output: Prints the PR URL."""
+
+import argparse
+import json
+import re
+import shutil
+import subprocess
+import sys
+import tempfile
+from pathlib import Path
+
+ROOT = Path(__file__).resolve().parent.parent.parent
+UPSTREAM_JSON = ROOT / ".imp" / "upstream.json"
+
+DEFAULT_REPO = "KKallas/Imp"
+
+
+def run(cmd, **kwargs):
+    return subprocess.run(cmd, capture_output=True, text=True, **kwargs)
+
+
+def load_upstream_repo():
+    """Read the upstream repo from .imp/upstream.json."""
+    if UPSTREAM_JSON.exists():
+        try:
+            data = json.loads(UPSTREAM_JSON.read_text())
+            if data.get("repo"):
+                return data["repo"]
+        except (json.JSONDecodeError, KeyError):
+            pass
+    return DEFAULT_REPO
+
+
+def main() -> int:
+    parser = argparse.ArgumentParser(description="Push a fix back to the upstream Imp repo")
+    parser.add_argument("--files", action="append", required=True,
+                        help="File to push (relative path, repeatable)")
+    parser.add_argument("--message", required=True,
+                        help="Commit message and PR title")
+    parser.add_argument("--repo", default=None,
+                        help="Upstream Imp repo (owner/name)")
+    args = parser.parse_args()
+
+    repo = args.repo or load_upstream_repo()
+
+    # Validate files exist locally
+    for f in args.files:
+        local = ROOT / f
+        if not local.exists():
+            print(f"Error: {f} does not exist.", file=sys.stderr)
+            return 1
+        if not local.is_file():
+            print(f"Error: {f} is not a file.", file=sys.stderr)
+            return 1
+
+    print(f"Upstream repo: {repo}")
+    print(f"Files to push: {', '.join(args.files)}")
+    print()
+
+    # Clone upstream
+    tmpdir = tempfile.mkdtemp(prefix="imp-pushfix-")
+    try:
+        print("Cloning upstream Imp repo...")
+        result = run(["gh", "repo", "clone", repo, tmpdir])
+        if result.returncode != 0:
+            print(f"Error cloning: {result.stderr}", file=sys.stderr)
+            return 1
+
+        # Create branch
+        slug = re.sub(r"[^a-z0-9]+", "-", args.message.lower())[:40].strip("-")
+        branch = f"fix/{slug}"
+        result = run(["git", "checkout", "-b", branch], cwd=tmpdir)
+        if result.returncode != 0:
+            print(f"Error creating branch: {result.stderr}", file=sys.stderr)
+            return 1
+
+        # Copy files
+        for f in args.files:
+            src = ROOT / f
+            dest = Path(tmpdir) / f
+            dest.parent.mkdir(parents=True, exist_ok=True)
+            shutil.copy2(src, dest)
+            print(f"  Copied: {f}")
+
+        # Commit
+        for f in args.files:
+            run(["git", "add", f], cwd=tmpdir)
+        result = run(["git", "commit", "-m", args.message], cwd=tmpdir)
+        if result.returncode != 0:
+            print(f"Error committing: {result.stderr}", file=sys.stderr)
+            return 1
+
+        # Push
+        print("Pushing to upstream...")
+        result = run(["git", "push", "-u", "origin", branch], cwd=tmpdir)
+        if result.returncode != 0:
+            print(f"Error pushing: {result.stderr}", file=sys.stderr)
+            return 1
+
+        # Create PR
+        print("Creating PR...")
+        result = run([
+            "gh", "pr", "create",
+            "--repo", repo,
+            "--title", args.message,
+            "--body", f"Bug fix pushed from a downstream project.\n\nFiles changed:\n"
+                      + "\n".join(f"- `{f}`" for f in args.files),
+            "--head", branch,
+            "--base", "main",
+        ], cwd=tmpdir)
+        pr_url = result.stdout.strip()
+        if result.returncode != 0:
+            print(f"Error creating PR: {result.stderr}", file=sys.stderr)
+            return 1
+        if pr_url:
+            print(f"\nPR: {pr_url}")
+
+        print("Done.")
+
+    finally:
+        shutil.rmtree(tmpdir, ignore_errors=True)
+
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/tools/imp/sync_upstream.py
+++ b/tools/imp/sync_upstream.py
@@ -1,0 +1,213 @@
+#!/usr/bin/env python3
+"""Pull latest Imp core updates into a project that has Imp copied in.
+
+Inputs:
+  --dry-run (flag): Show what would change without applying anything.
+  --repo: str — upstream Imp repo (default: read from .imp/upstream.json, or "KKallas/Imp").
+
+Process:
+  1. Reads .imp/upstream.json for the last synced commit and core paths
+  2. Downloads the latest Imp main branch to a temp directory
+  3. Compares core files and shows a diff summary
+  4. Applies changes (unless --dry-run)
+  5. Updates .imp/upstream.json with the new commit hash
+
+Output: Prints a summary of updated, added, and unchanged files."""
+
+import argparse
+import json
+import os
+import shutil
+import subprocess
+import sys
+import tempfile
+from datetime import date
+from pathlib import Path
+
+ROOT = Path(__file__).resolve().parent.parent.parent
+UPSTREAM_JSON = ROOT / ".imp" / "upstream.json"
+
+DEFAULT_REPO = "KKallas/Imp"
+DEFAULT_CORE_PATHS = [
+    "server/",
+    "pipeline/",
+    "renderers/",
+    "public/",
+    "static/",
+    "imp.py",
+    "requirements.txt",
+    "tools/__init__.py",
+    "workflows/__init__.py",
+    "tools/imp/",
+    "tools/render/",
+    "tools/presets/",
+]
+
+
+def run(cmd, **kwargs):
+    return subprocess.run(cmd, capture_output=True, text=True, **kwargs)
+
+
+def load_upstream_config():
+    """Load .imp/upstream.json or return defaults."""
+    if UPSTREAM_JSON.exists():
+        try:
+            return json.loads(UPSTREAM_JSON.read_text())
+        except (json.JSONDecodeError, KeyError):
+            pass
+    return {
+        "repo": DEFAULT_REPO,
+        "commit": None,
+        "synced_at": None,
+        "core_paths": DEFAULT_CORE_PATHS,
+    }
+
+
+def save_upstream_config(config):
+    UPSTREAM_JSON.parent.mkdir(parents=True, exist_ok=True)
+    UPSTREAM_JSON.write_text(json.dumps(config, indent=2) + "\n")
+
+
+def is_core_path(filepath, core_paths):
+    """Check if a file path falls under one of the core paths."""
+    for cp in core_paths:
+        if cp.endswith("/"):
+            if filepath.startswith(cp):
+                return True
+        else:
+            if filepath == cp:
+                return True
+    return False
+
+
+def collect_core_files(base_dir, core_paths):
+    """Collect all files under core paths relative to base_dir."""
+    files = {}
+    for cp in core_paths:
+        full = base_dir / cp
+        if full.is_file():
+            files[cp] = full.read_bytes()
+        elif full.is_dir():
+            for f in sorted(full.rglob("*")):
+                if f.is_file():
+                    rel = str(f.relative_to(base_dir))
+                    files[rel] = f.read_bytes()
+    return files
+
+
+def main() -> int:
+    parser = argparse.ArgumentParser(description="Pull latest Imp core updates")
+    parser.add_argument("--dry-run", action="store_true", help="Show changes without applying")
+    parser.add_argument("--repo", default=None, help="Upstream Imp repo (owner/name)")
+    args = parser.parse_args()
+
+    config = load_upstream_config()
+    repo = args.repo or config.get("repo", DEFAULT_REPO)
+    core_paths = config.get("core_paths", DEFAULT_CORE_PATHS)
+    last_commit = config.get("commit")
+
+    if last_commit:
+        print(f"Last synced: {last_commit[:8]} ({config.get('synced_at', 'unknown')})")
+    else:
+        print("No previous sync recorded. Will do a full comparison.")
+
+    print(f"Upstream: {repo}")
+    print(f"Core paths: {len(core_paths)} entries")
+    print()
+
+    # Clone upstream to temp dir
+    tmpdir = tempfile.mkdtemp(prefix="imp-sync-")
+    try:
+        print("Fetching latest Imp from GitHub...")
+        result = run(
+            ["gh", "repo", "clone", repo, tmpdir, "--", "--depth=1"],
+        )
+        if result.returncode != 0:
+            print(f"Error cloning upstream: {result.stderr}", file=sys.stderr)
+            return 1
+
+        # Get the upstream HEAD commit
+        result = run(["git", "rev-parse", "HEAD"], cwd=tmpdir)
+        upstream_commit = result.stdout.strip()
+        print(f"Upstream HEAD: {upstream_commit[:8]}")
+
+        if upstream_commit == last_commit:
+            print("\nAlready up to date.")
+            return 0
+
+        # Collect files from both sides
+        upstream_files = collect_core_files(Path(tmpdir), core_paths)
+        local_files = collect_core_files(ROOT, core_paths)
+
+        # Compare
+        updated = []
+        added = []
+        unchanged = []
+
+        all_paths = sorted(set(upstream_files.keys()) | set(local_files.keys()))
+        for path in all_paths:
+            if path not in upstream_files:
+                # File exists locally but not upstream — local addition, skip
+                continue
+            if path not in local_files:
+                added.append(path)
+            elif upstream_files[path] != local_files[path]:
+                updated.append(path)
+            else:
+                unchanged.append(path)
+
+        # Summary
+        print(f"\n--- Sync summary ---")
+        print(f"  Updated:   {len(updated)}")
+        print(f"  Added:     {len(added)}")
+        print(f"  Unchanged: {len(unchanged)}")
+
+        if updated:
+            print("\nFiles to update:")
+            for f in updated:
+                print(f"  M {f}")
+        if added:
+            print("\nFiles to add:")
+            for f in added:
+                print(f"  A {f}")
+
+        if not updated and not added:
+            print("\nNo core file changes to apply.")
+            # Still update tracking
+            if not args.dry_run:
+                config["commit"] = upstream_commit
+                config["synced_at"] = str(date.today())
+                config["repo"] = repo
+                save_upstream_config(config)
+                print("Updated .imp/upstream.json")
+            return 0
+
+        if args.dry_run:
+            print("\n(dry run — no changes applied)")
+            return 0
+
+        # Apply changes
+        print("\nApplying changes...")
+        for path in updated + added:
+            dest = ROOT / path
+            dest.parent.mkdir(parents=True, exist_ok=True)
+            dest.write_bytes(upstream_files[path])
+            print(f"  {'M' if path in updated else 'A'} {path}")
+
+        # Update tracking
+        config["commit"] = upstream_commit
+        config["synced_at"] = str(date.today())
+        config["repo"] = repo
+        config["core_paths"] = core_paths
+        save_upstream_config(config)
+        print(f"\nDone. Synced to {upstream_commit[:8]}.")
+        print("Review the changes, then commit when ready.")
+
+    finally:
+        shutil.rmtree(tmpdir, ignore_errors=True)
+
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())


### PR DESCRIPTION
## Summary

Closes #175

When Imp is copied into a new project (download zip → paste → run `imp.py`), these two tools handle keeping Imp up to date:

- **`sync_upstream.py`** — Pulls latest Imp core updates. Compares only core files (server/, pipeline/, tools/imp/, etc.) against upstream, applies changes, leaves project-specific tools/workflows untouched. Tracks last synced commit in `.imp/upstream.json`.
- **`push_fix.py`** — Pushes a bug fix back to the Imp repo as a PR. Clones upstream, copies specified files, creates branch + PR.

## How it works

The foreman can run these when asked ("update imp to latest" → sync_upstream, "push this fix to imp" → push_fix).

Core vs project-specific files are defined in `.imp/upstream.json`:
```json
{
  "repo": "KKallas/Imp",
  "commit": "f45f83c",
  "synced_at": "2026-05-04",
  "core_paths": ["server/", "pipeline/", "tools/imp/", ...]
}
```

## Test plan

- [ ] Copy Imp into an empty folder, run `imp.py`, set up a project via the wizard
- [ ] Run `sync_upstream.py --dry-run` — should show no changes (just copied)
- [ ] Make a change to a core file in the Imp repo
- [ ] Run `sync_upstream.py` — should pull the change
- [ ] Run `push_fix.py --files <file> --message "test"` — should create PR on Imp repo

🤖 Generated with [Claude Code](https://claude.com/claude-code)