### PR TITLE
Fix 'Waiting for approval' stuck state

### DIFF
--- a/server/chat_ws.py
+++ b/server/chat_ws.py
@@ -142,7 +142,7 @@ async def handle_ws_chat(ws: WebSocket) -> None:
     except Exception:
         pass
 
-    confirm_queue: asyncio.Queue[bool] = asyncio.Queue()
+    confirm_queue: asyncio.Queue[bool | None] = asyncio.Queue()
     _confirm_counter = [0]
 
     async def confirm_tool(tool: str, description: str, preview: str) -> bool:
@@ -155,7 +155,10 @@ async def handle_ws_chat(ws: WebSocket) -> None:
             "description": description,
             "preview": preview[:3000],
         })
-        return await confirm_queue.get()
+        result = await confirm_queue.get()
+        if result is None:
+            raise asyncio.CancelledError()
+        return result
 
     try:
         while True:
@@ -167,7 +170,15 @@ async def handle_ws_chat(ws: WebSocket) -> None:
 
             if msg.get("type") == "stop":
                 if current_task and not current_task.done():
+                    # Wake any blocked confirm_queue.get() so cancel propagates.
+                    confirm_queue.put_nowait(None)
                     current_task.cancel()
+                    # Drain stale entries so they can't leak into the next turn.
+                    while not confirm_queue.empty():
+                        try:
+                            confirm_queue.get_nowait()
+                        except asyncio.QueueEmpty:
+                            break
                     await ws.send_json({"type": "status", "text": ""})
                     await ws.send_json({"type": "done", "full_text": "(stopped)"})
                 continue
@@ -221,6 +232,13 @@ async def handle_ws_chat(ws: WebSocket) -> None:
             session.append_turn("user", text)
             session.truncate()
             chat_history.save_session(session)
+
+            # Drain any stale confirm entries from a prior aborted turn.
+            while not confirm_queue.empty():
+                try:
+                    confirm_queue.get_nowait()
+                except asyncio.QueueEmpty:
+                    break
 
             # Status
             await ws.send_json({"type": "status", "text": "Thinking..."})

--- a/server/chat_ws.py
+++ b/server/chat_ws.py
@@ -179,8 +179,11 @@ async def handle_ws_chat(ws: WebSocket) -> None:
                             confirm_queue.get_nowait()
                         except asyncio.QueueEmpty:
                             break
-                    await ws.send_json({"type": "status", "text": ""})
-                    await ws.send_json({"type": "done", "full_text": "(stopped)"})
+                # Always clear the task ref so the user can send a new message
+                # even if cancel() didn't fully propagate through the SDK.
+                current_task = None
+                await ws.send_json({"type": "status", "text": ""})
+                await ws.send_json({"type": "done", "full_text": "(stopped)"})
                 continue
 
             if msg.get("type") == "confirm_response":

--- a/static/imp-chat.js
+++ b/static/imp-chat.js
@@ -303,7 +303,10 @@ function connectWs() {
           `<button class="wf-btn" style="color:#da3633;border-color:#da3633;" onclick="respondConfirm('${confirmId}',false)">Reject</button></div>` +
           `</details></div>\n\n`;
         renderAgentBody();
-        setStatus('Waiting for approval...');
+        // Scroll the approval block into view
+        const block = document.querySelector(`[data-confirm-id="${confirmId}"]`);
+        if (block) block.scrollIntoView({ behavior: 'smooth', block: 'center' });
+        setStatus(`<a href="#" style="color:var(--accent)" onclick="event.preventDefault();var b=document.querySelector('[data-confirm-id=\\'${confirmId}\\']');if(b)b.scrollIntoView({behavior:'smooth',block:'center'})">Waiting for approval (click to view)</a>`);
         break;
       }
     }
@@ -338,7 +341,13 @@ function send() {
 }
 
 function stop() {
-  if (ws) ws.send(JSON.stringify({ type: 'stop' }));
+  if (ws && ws.readyState === WebSocket.OPEN) {
+    ws.send(JSON.stringify({ type: 'stop' }));
+  }
+  // Always clear local UI — server-side cancel is best-effort.
+  setWorking(false);
+  setStatus('');
+  pendingTools = {};
 }
 
 function onKey(e) {

--- a/static/imp.css
+++ b/static/imp.css
@@ -28,6 +28,8 @@
 .imp-fold.running { border-color:var(--accent); }
 .imp-fold .imp-fold-body { padding:8px 10px; border-top:1px solid var(--border);
   font-size:12px; color:var(--muted); line-height:1.5; }
+.confirm-block { border-left:3px solid #d29922; background:#d2992210;
+  border-radius:6px; padding:2px 0; margin:8px 0; }
 
 /* --- layout --- */
 body { font-family:-apple-system,BlinkMacSystemFont,"Segoe UI",Roboto,sans-serif;


### PR DESCRIPTION
## Summary

Closes #179

Three bugs that together cause the chat to get stuck on "Waiting for approval..." with no way out:

**Bug 1 — Stop silently dropped when WS disconnected** (`imp-chat.js`)
- `stop()` now checks `ws.readyState` and always clears local UI regardless

**Bug 2 — Server-side confirm queue uncancellable** (`chat_ws.py`)
- Stop now pushes a `None` sentinel to unblock `confirm_queue.get()`
- `confirm_tool` raises `CancelledError` on `None` so the SDK unwinds cleanly
- Queue is drained on stop and before each new dispatch to prevent stale entries

**Bug 3 — Approval block renders off-screen** (`imp-chat.js` + `imp.css`)
- Confirm block auto-scrolls into view on render
- Yellow left-border highlight so it stands out from tool blocks
- Status bar text is clickable to re-scroll to the prompt

## Test plan

- [ ] Stop while WS open, no pending approval — status clears, input re-enables
- [ ] Stop while WS open, pending approval — status clears, no orphaned task
- [ ] Stop while WS dropped — status clears even though server is down
- [ ] Approval visibility — block scrolls into view with highlight, status bar is clickable
- [ ] Stale confirm_response — stop + new message doesn't auto-approve from leftover queue entry

🤖 Generated with [Claude Code](https://claude.com/claude-code)