### PR TITLE
Fix agent context loss between turns (#181)

### DIFF
--- a/server/chat_history.py
+++ b/server/chat_history.py
@@ -465,13 +465,36 @@ def history_preamble(turns: Iterable[Turn]) -> str:
     we don't simulate an API conversation because re-querying prior
     turns through the SDK would re-execute their tool calls. The LLM
     is told these are for context only.
+
+    For assistant turns we also include:
+    - a compact tool-call summary (name + status) so the agent knows
+      what was already executed,
+    - the last thinking snippet (truncated) so the reasoning chain
+      survives across turns.
     """
+    _THINKING_CAP = 300  # chars — keep preamble lean
+
     lines: list[str] = []
     for t in turns:
-        if not t.content.strip():
-            continue
         label = "User" if t.role == "user" else "Assistant"
-        lines.append(f"{label}: {t.content.strip()}")
+        parts: list[str] = []
+        if t.content.strip():
+            parts.append(t.content.strip())
+        if t.thinking:
+            snippet = t.thinking[-1].strip()
+            if len(snippet) > _THINKING_CAP:
+                snippet = snippet[:_THINKING_CAP] + "…"
+            parts.append(f"[Thinking: {snippet}]")
+        if t.tool_calls:
+            summaries = []
+            for tc in t.tool_calls:
+                name = tc.get("name", "?")
+                status = tc.get("status", "")
+                summaries.append(f"{name}({status})" if status else name)
+            parts.append(f"[Tools used: {', '.join(summaries)}]")
+        if not parts:
+            continue
+        lines.append(f"{label}: " + "\n".join(parts))
     if not lines:
         return ""
     body = "\n\n".join(lines)

--- a/tests/test_chat_history.py
+++ b/tests/test_chat_history.py
@@ -308,6 +308,56 @@ async def test_history_preamble_is_empty_for_empty_history() -> None:
     print("test_history_preamble_is_empty_for_empty_history: OK")
 
 
+async def test_preamble_includes_thinking_and_tool_calls() -> None:
+    """Assistant turns with thinking and tool_calls must surface that
+    context in the preamble so the agent doesn't lose its reasoning."""
+    t = chat_history.Turn(
+        role="assistant",
+        content="Fixed the bug.",
+        thinking=["short thought", "I concluded the root cause is X"],
+        tool_calls=[
+            {"name": "edit_file", "status": "ok"},
+            {"name": "git_commit", "status": "ok"},
+        ],
+    )
+    preamble = chat_history.history_preamble([t])
+    assert "I concluded the root cause is X" in preamble
+    assert "edit_file(ok)" in preamble
+    assert "git_commit(ok)" in preamble
+    print("test_preamble_includes_thinking_and_tool_calls: OK")
+
+
+async def test_preamble_includes_tool_only_turns() -> None:
+    """Turns where the assistant used tools but produced no prose must
+    still appear — this is the core bug where context was lost."""
+    t = chat_history.Turn(
+        role="assistant",
+        content="",
+        thinking=["Applying the fix now"],
+        tool_calls=[{"name": "edit_file", "status": "ok"}],
+    )
+    preamble = chat_history.history_preamble([t])
+    assert preamble != ""
+    assert "Applying the fix now" in preamble
+    assert "edit_file(ok)" in preamble
+    print("test_preamble_includes_tool_only_turns: OK")
+
+
+async def test_preamble_truncates_long_thinking() -> None:
+    """Thinking snippets longer than 300 chars are truncated."""
+    long_thought = "x" * 500
+    t = chat_history.Turn(
+        role="assistant",
+        content="done",
+        thinking=[long_thought],
+    )
+    preamble = chat_history.history_preamble([t])
+    # Should be capped at 300 + ellipsis
+    assert "x" * 300 + "…" in preamble
+    assert "x" * 301 not in preamble
+    print("test_preamble_truncates_long_thinking: OK")
+
+
 # ---------- /new rotates: current session persists, new one starts fresh ----------
 
 
@@ -355,6 +405,9 @@ async def amain() -> None:
         test_load_session_returns_none_for_missing_id,
         test_resume_round_trip_supports_history_preamble,
         test_history_preamble_is_empty_for_empty_history,
+        test_preamble_includes_thinking_and_tool_calls,
+        test_preamble_includes_tool_only_turns,
+        test_preamble_truncates_long_thinking,
         test_rotate_flow_preserves_old_session_on_disk,
     ]
     for t in tests:


### PR DESCRIPTION
## Summary
- `history_preamble()` now includes thinking snippets and tool-call summaries for assistant turns, not just `t.content`
- Turns where the agent used tools but produced no prose are no longer silently skipped
- Thinking snippets are capped at 300 chars to keep the preamble lean

Closes #181

## Test plan
- [x] Existing preamble tests still pass
- [x] New test: thinking + tool calls appear in preamble
- [x] New test: tool-only turns (empty content) are visible
- [x] New test: long thinking snippets are truncated
- [ ] Manual: run a multi-step workflow (fix → test → PR) and verify the agent retains context through to PR creation

🤖 Generated with [Claude Code](https://claude.com/claude-code)