### PR TITLE
Save tool-only turns and fix thinking config (#183)

### DIFF
--- a/server/chat_ws.py
+++ b/server/chat_ws.py
@@ -294,8 +294,11 @@ async def handle_ws_chat(ws: WebSocket) -> None:
                         confirm=confirm_tool,
                     )
 
-                    # Save assistant turn with full structured log
-                    if reply:
+                    # Save assistant turn with full structured log.
+                    # Always save — even tool-only turns with no prose —
+                    # so thinking + tool context survives in history.
+                    has_content = reply or turn_ui.tool_log or turn_ui.thinking_log
+                    if has_content:
                         session.append_turn(
                             "assistant",
                             reply,

--- a/server/foreman_agent.py
+++ b/server/foreman_agent.py
@@ -212,6 +212,7 @@ async def dispatch(
         ResultMessage,
         TextBlock,
         ThinkingBlock,
+        ThinkingConfigEnabled,
         ToolUseBlock,
         UserMessage,
     )
@@ -224,7 +225,7 @@ async def dispatch(
         system_prompt=_load_system_prompt(),
         can_use_tool=_make_security_hook(confirm),
         max_turns=20,
-        thinking={"type": "enabled", "budget_tokens": 10000},
+        thinking=ThinkingConfigEnabled(budget_tokens=10000),
     )
 
     cm_factory = thinking if thinking is not None else (lambda _label: _NullAsyncContext())
@@ -270,6 +271,11 @@ async def dispatch(
                                 )
 
                         for b in msg_thinking:
+                            print(
+                                f"[foreman] thinking block: {len(b.thinking)} chars, "
+                                f"preview={b.thinking[:80]!r}",
+                                file=sys.stderr,
+                            )
                             await ui.thinking_update(b.thinking)
 
                         # Register new tool calls in the tracker

--- a/server/setup_agent.py
+++ b/server/setup_agent.py
@@ -522,6 +522,7 @@ async def run_setup(
         "Hi — I'm the **Setup Agent**. Let me check what's needed to get "
         "Imp running.\n\n"
     )
+    print("[setup] greeting sent, initializing SDK...", file=sys.stderr)
 
     import time
 
@@ -540,6 +541,7 @@ async def run_setup(
         can_use_tool=_allow_all,
         max_turns=30,
     )
+    print("[setup] SDK options ready, starting agent loop...", file=sys.stderr)
 
     pending_tools: dict[str, tuple[str, float]] = {}  # tool_id -> (name, start_time)
 
@@ -557,6 +559,7 @@ async def run_setup(
     current_turn = "start"
     async with ClaudeSDKClient(options=options) as client:
         while True:
+            print(f"[setup] querying: {current_turn!r}", file=sys.stderr)
             await client.query(current_turn)
             assistant_text_parts: list[str] = []
             async for message in client.receive_response():
@@ -577,14 +580,17 @@ async def run_setup(
                             await _handle_result(block)
 
             reply = "".join(assistant_text_parts).strip()
+            print(f"[setup] reply: {reply[:120]!r}...", file=sys.stderr)
             if reply:
                 await say(reply)
 
             if is_setup_complete():
+                print("[setup] setup complete!", file=sys.stderr)
                 return
 
             next_turn = await ask("(reply to Setup Agent)")
             if next_turn is None:
                 await say("No response — setup paused here. Refresh to resume.")
                 return
+            print(f"[setup] user replied: {next_turn!r}", file=sys.stderr)
             current_turn = next_turn


### PR DESCRIPTION
## Summary
- **Tool-only turns now saved**: `if reply:` → `if reply or tool_log or thinking_log:` so agent context survives across turns even when there's no prose
- **Thinking config fixed**: use `ThinkingConfigEnabled` SDK class instead of raw dict that included an unexpected `type` key
- **Setup logging**: `[setup]` stderr logs at each step so hangs are diagnosable from the terminal
- **Thinking debug log**: `[foreman]` log shows thinking block size and preview

Closes #183

## Test plan
- [x] Existing preamble tests pass
- [ ] Manual: restart Imp on fresh project, check terminal shows `[setup]` progress
- [ ] Manual: send a message that triggers tool-only work, verify thinking blocks appear and turn is persisted in chat history
- [ ] Manual: multi-step workflow (fix → test → PR) retains context through to completion

🤖 Generated with [Claude Code](https://claude.com/claude-code)