### PR TITLE
Fix KeyError: 'type' in thinking config

### DIFF
--- a/server/foreman_agent.py
+++ b/server/foreman_agent.py
@@ -212,7 +212,6 @@ async def dispatch(
         ResultMessage,
         TextBlock,
         ThinkingBlock,
-        ThinkingConfigEnabled,
         ToolUseBlock,
         UserMessage,
     )
@@ -225,7 +224,7 @@ async def dispatch(
         system_prompt=_load_system_prompt(),
         can_use_tool=_make_security_hook(confirm),
         max_turns=20,
-        thinking=ThinkingConfigEnabled(budget_tokens=10000),
+        thinking={"type": "enabled", "budget_tokens": 10000},
     )
 
     cm_factory = thinking if thinking is not None else (lambda _label: _NullAsyncContext())


### PR DESCRIPTION
## Summary
- Reverts `ThinkingConfigEnabled(budget_tokens=10000)` back to `{"type": "enabled", "budget_tokens": 10000}`
- The SDK class omits the `type` key, but the SDK internally does `config["type"]` which crashes

One-line fix for the `KeyError: 'type'` introduced in #184.

## Test plan
- [ ] Start Imp, send a message — no more `KeyError: 'type'`

🤖 Generated with [Claude Code](https://claude.com/claude-code)