### PR TITLE
Save partial turns when agent is stopped or errors (#186)

### DIFF
--- a/server/chat_ws.py
+++ b/server/chat_ws.py
@@ -324,17 +324,36 @@ async def handle_ws_chat(ws: WebSocket) -> None:
                         "chat_id": chat_id,
                     })
 
-                except asyncio.CancelledError:
-                    await _safe_send({"type": "done", "full_text": "(stopped)"})
-                except Exception as exc:
-                    print(
-                        f"[chat_ws] dispatch error: {type(exc).__name__}: {exc}",
-                        file=sys.stderr,
-                    )
-                    await _safe_send({
-                        "type": "error",
-                        "text": f"{type(exc).__name__}: {exc}",
-                    })
+                except (asyncio.CancelledError, Exception) as exc:
+                    is_cancel = isinstance(exc, asyncio.CancelledError)
+                    if not is_cancel:
+                        print(
+                            f"[chat_ws] dispatch error: {type(exc).__name__}: {exc}",
+                            file=sys.stderr,
+                        )
+
+                    # Save whatever the agent produced before it was
+                    # interrupted so partial work isn't lost from history.
+                    partial = turn_ui.tool_log or turn_ui.thinking_log
+                    if partial:
+                        session.append_turn(
+                            "assistant",
+                            "(stopped)" if is_cancel else f"(error: {exc})",
+                            tool_calls=turn_ui.tool_log,
+                            thinking=turn_ui.thinking_log,
+                            artifacts=turn_ui.artifact_log,
+                            blocks=turn_ui.blocks_log,
+                        )
+                        session.truncate()
+                        chat_history.save_session(session)
+
+                    if is_cancel:
+                        await _safe_send({"type": "done", "full_text": "(stopped)"})
+                    else:
+                        await _safe_send({
+                            "type": "error",
+                            "text": f"{type(exc).__name__}: {exc}",
+                        })
 
             current_task = asyncio.create_task(_run_dispatch())
 


### PR DESCRIPTION
## Summary
- When the user clicks Stop mid-turn, save all thinking + tool work accumulated so far instead of discarding it
- Same for error cases — partial progress is preserved in history
- Content is saved as `(stopped)` or `(error: ...)` so it's clear the turn didn't complete

Closes #186

## Test plan
- [ ] Start a long task, click Stop mid-way — partial tool blocks should persist in chat history
- [ ] Refresh the page — the stopped turn should still be visible
- [ ] Send a follow-up message — agent should have context about what was already done

🤖 Generated with [Claude Code](https://claude.com/claude-code)