### PR TITLE
Pin claude-agent-sdk==0.1.58 — 0.1.72 breaks thinking (#188)

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -1,4 +1,4 @@
-claude-agent-sdk
+claude-agent-sdk==0.1.58
 plotly>=5
 pandas>=2
 html2image>=2.0


### PR DESCRIPTION
## Summary
- Pin `claude-agent-sdk==0.1.58` in requirements.txt
- SDK 0.1.72 returns `ThinkingBlock` with empty `.thinking` text — confirmed by direct test
- This was why thinking worked in the standalone Imp (old venv, 0.1.58) but was empty in minesweepers/Imp (fresh venv, 0.1.72)

Closes #188

## Test plan
- [ ] Delete `minesweepers/Imp/.venv/`, restart `python3 Imp/imp.py` — venv recreated with 0.1.58
- [ ] Send a message — thinking blocks should have content

🤖 Generated with [Claude Code](https://claude.com/claude-code)