### PR TITLE
Allow configuring LLM backend before setup starts

### DIFF
--- a/server/chat_ws.py
+++ b/server/chat_ws.py
@@ -105,8 +105,27 @@ async def handle_ws_chat(ws: WebSocket) -> None:
 
     # Auto-start setup if needed
     try:
-        from server.setup_agent import is_setup_complete
+        from server.setup_agent import is_setup_complete, has_llm_access
         if not is_setup_complete():
+            # Check if we have any LLM access before starting the setup agent
+            if not has_llm_access():
+                # No Claude auth and no custom backend configured — ask user
+                # to configure an LLM backend first via the bootstrap UI.
+                await ws.send_json({"type": "need_llm_config"})
+                # Wait for the user to complete LLM bootstrap, then retry
+                while True:
+                    raw2 = await ws.receive_text()
+                    msg2 = json.loads(raw2)
+                    if msg2.get("type") == "llm_configured":
+                        # User completed bootstrap — re-check and proceed
+                        if has_llm_access():
+                            break
+                        else:
+                            await ws.send_json({"type": "need_llm_config"})
+                    elif msg2.get("type") == "message":
+                        # User tried to chat before configuring — remind them
+                        await ws.send_json({"type": "need_llm_config"})
+
             from server import setup_agent
 
             async def setup_say(t: str) -> None:

--- a/server/render_route.py
+++ b/server/render_route.py
@@ -152,6 +152,62 @@ async def setup_status():
     return {"complete": complete}
 
 
+@app.get("/api/llm-presets")
+async def llm_presets():
+    """Return available LLM backend presets for the bootstrap UI."""
+    import importlib.util
+
+    options_path = _ROOT / "tools" / "llm" / "options.py"
+    spec = importlib.util.spec_from_file_location("llm_options", options_path)
+    mod = importlib.util.module_from_spec(spec)
+    spec.loader.exec_module(mod)
+    return {"presets": mod.PRESETS}
+
+
+@app.post("/api/llm-bootstrap")
+async def llm_bootstrap(request: Request):
+    """Configure LLM backend before setup starts.
+
+    Accepts: {model, base_url, api_key_env, api_key}
+    Writes the llm block to .imp/config.json and stores the key in keychain.
+    """
+    data = await request.json()
+    model = data.get("model", "")
+    base_url = data.get("base_url", "")
+    api_key_env = data.get("api_key_env", "")
+    api_key = data.get("api_key", "")
+
+    if not model or not base_url:
+        return Response(
+            json.dumps({"error": "model and base_url are required"}),
+            status_code=400,
+            media_type="application/json",
+        )
+
+    # Write LLM config
+    cfg = _load_imp_config()
+    cfg["llm"] = {
+        "model": model,
+        "base_url": base_url,
+        "api_key_env": api_key_env or "ANTHROPIC_API_KEY",
+    }
+    _save_imp_config(cfg)
+
+    # Store API key in OS keychain if provided
+    if api_key and api_key_env:
+        from server import keystore
+        keystore.set(api_key_env, api_key)
+
+    return {"ok": True, "llm": cfg["llm"]}
+
+
+@app.get("/api/llm-status")
+async def llm_status():
+    """Check if any LLM backend is accessible."""
+    from server.setup_agent import has_llm_access
+    return {"has_access": has_llm_access()}
+
+
 @app.post("/api/reload-prompt")
 async def reload_prompt():
     """Force-reload the Foreman system prompt (re-scans tools and workflows)."""

--- a/server/setup_agent.py
+++ b/server/setup_agent.py
@@ -623,7 +623,16 @@ async def run_setup(
                         if isinstance(block, TextBlock):
                             assistant_text_parts.append(block.text)
                         elif isinstance(block, ToolUseBlock):
-                            desc = (block.input or {}).get("description", block.name)
+                            # Non-Anthropic backends sometimes serialize tool input as a
+                            # JSON string instead of a dict — handle both.
+                            raw = block.input
+                            if isinstance(raw, str):
+                                try:
+                                    raw = json.loads(raw)
+                                except (json.JSONDecodeError, TypeError):
+                                    raw = {}
+                            args = raw if isinstance(raw, dict) else {}
+                            desc = args.get("description", block.name)
                             pending_tools[block.id] = (block.name, time.time())
                             if tool_start:
                                 await tool_start(block.name, {"description": desc})

--- a/server/setup_agent.py
+++ b/server/setup_agent.py
@@ -54,6 +54,54 @@ def is_setup_complete() -> bool:
     return load_config().get("setup_complete", False)
 
 
+def has_llm_access() -> bool:
+    """Check if any LLM backend is reachable (Claude auth or custom config).
+
+    Returns True if:
+    - ANTHROPIC_API_KEY is set, OR
+    - Claude Code CLI is logged in (claude_agent_sdk importable), OR
+    - A custom LLM backend is configured in .imp/config.json with a resolvable key.
+    """
+    import os
+
+    # Direct Anthropic key
+    if os.environ.get("ANTHROPIC_API_KEY"):
+        return True
+
+    # Custom backend configured?
+    cfg = load_config()
+    llm = cfg.get("llm") or {}
+    if llm.get("base_url"):
+        # Has a custom backend — check if key is available
+        api_key_env = llm.get("api_key_env", "")
+        if not api_key_env or api_key_env == "ANTHROPIC_API_KEY":
+            return True  # No special key needed
+        if os.environ.get(api_key_env):
+            return True
+        # Check OS keychain
+        try:
+            from . import keystore
+            if keystore.get(api_key_env):
+                return True
+        except Exception:
+            pass
+        return False
+
+    # Try Claude Code CLI session (SDK can auth without explicit key)
+    try:
+        import subprocess
+        result = subprocess.run(
+            ["claude", "--version"],
+            capture_output=True, timeout=5,
+        )
+        if result.returncode == 0:
+            return True
+    except Exception:
+        pass
+
+    return False
+
+
 # ---------- gh / git helpers ----------
 
 
@@ -536,10 +584,17 @@ async def run_setup(
     )
     from claude_agent_sdk.types import ToolResultBlock
 
+    # Honor custom LLM backend config (e.g. Kimi via OpenRouter)
+    from .foreman_agent import _load_llm_config, _llm_sdk_kwargs
+
+    llm_cfg = _load_llm_config()
+    llm_kwargs = _llm_sdk_kwargs(llm_cfg)
+
     options = ClaudeAgentOptions(
         system_prompt=_build_setup_prompt(),
         can_use_tool=_allow_all,
         max_turns=30,
+        **llm_kwargs,
     )
     print("[setup] SDK options ready, starting agent loop...", file=sys.stderr)
 

--- a/static/imp-chat.js
+++ b/static/imp-chat.js
@@ -286,6 +286,10 @@ function connectWs() {
         unlockTabs();
         break;
 
+      case 'need_llm_config':
+        showLlmBootstrap();
+        break;
+
       case 'dashboard':
         openDashboard(msg.html || '');
         break;
@@ -364,6 +368,93 @@ function respondApiKey(envVar, cancel) {
   var btnRe = new RegExp('<div style="padding:0 12px 10px;display:flex[\\s\\S]*?</div></div>');
   agentText = agentText.replace(btnRe, '<div style="padding:4px 12px 10px;font-size:11px;color:var(--muted);">' + icon + ' ' + label + '</div></div>');
   renderAgentBody();
+}
+
+function showLlmBootstrap() {
+  // Show LLM backend picker in the messages area
+  if (activeTab !== 'chat') switchTab('chat');
+  var msgs = document.getElementById('messages');
+  msgs.innerHTML = '';
+  var div = document.createElement('div');
+  div.className = 'msg agent';
+  div.innerHTML = '<div class="llm-bootstrap">' +
+    '<h3 style="margin:0 0 8px;">Configure LLM Backend</h3>' +
+    '<p style="margin:0 0 12px;color:var(--muted);font-size:13px;">' +
+    'No Claude access detected. Configure an alternative LLM backend to proceed with setup.</p>' +
+    '<div id="llm-presets-list" style="margin-bottom:12px;"><em>Loading presets...</em></div>' +
+    '<div style="border-top:1px solid var(--border);padding-top:12px;">' +
+    '<label style="font-size:12px;color:var(--muted);display:block;margin-bottom:4px;">API Key</label>' +
+    '<input type="password" id="llm-bootstrap-key" placeholder="Paste your API key" ' +
+    'style="width:100%;padding:8px 10px;background:var(--bg);color:var(--fg);border:1px solid var(--border);border-radius:4px;font-family:monospace;font-size:13px;box-sizing:border-box;margin-bottom:12px;">' +
+    '<button id="llm-bootstrap-btn" class="wf-start" onclick="submitLlmBootstrap()" disabled>Connect</button>' +
+    '<span id="llm-bootstrap-status" style="margin-left:8px;font-size:12px;color:var(--muted);"></span>' +
+    '</div></div>';
+  msgs.appendChild(div);
+  // Fetch presets
+  fetch(API + '/api/llm-presets').then(function(r) { return r.json(); }).then(function(data) {
+    var list = document.getElementById('llm-presets-list');
+    if (!list) return;
+    var presets = (data.presets || []).filter(function(p) { return p.base_url !== 'https://api.anthropic.com'; });
+    var html = '';
+    presets.forEach(function(p, i) {
+      html += '<label style="display:flex;align-items:center;gap:8px;padding:8px 10px;border:1px solid var(--border);border-radius:4px;margin-bottom:6px;cursor:pointer;">' +
+        '<input type="radio" name="llm-preset" value="' + i + '" onchange="selectLlmPreset(' + i + ')" style="margin:0;">' +
+        '<div><strong>' + p.name + '</strong><br><span style="font-size:11px;color:var(--muted);">' + p.model + ' &middot; ' + p.notes + '</span></div>' +
+        '</label>';
+    });
+    list.innerHTML = html;
+    window._llmPresets = presets;
+  }).catch(function() {
+    var list = document.getElementById('llm-presets-list');
+    if (list) list.innerHTML = '<em style="color:#da3633;">Failed to load presets</em>';
+  });
+}
+
+function selectLlmPreset(index) {
+  window._selectedLlmPreset = window._llmPresets[index];
+  var btn = document.getElementById('llm-bootstrap-btn');
+  if (btn) btn.disabled = false;
+}
+
+function submitLlmBootstrap() {
+  var preset = window._selectedLlmPreset;
+  if (!preset) return;
+  var key = document.getElementById('llm-bootstrap-key').value.trim();
+  var status = document.getElementById('llm-bootstrap-status');
+  var btn = document.getElementById('llm-bootstrap-btn');
+  if (!key) {
+    if (status) status.textContent = 'API key is required';
+    return;
+  }
+  if (btn) btn.disabled = true;
+  if (status) status.textContent = 'Saving...';
+  fetch(API + '/api/llm-bootstrap', {
+    method: 'POST',
+    headers: {'Content-Type': 'application/json'},
+    body: JSON.stringify({
+      model: preset.model,
+      base_url: preset.base_url,
+      api_key_env: preset.api_key_env,
+      api_key: key
+    })
+  }).then(function(r) { return r.json(); }).then(function(data) {
+    if (data.ok) {
+      if (status) status.textContent = 'Connected! Starting setup...';
+      // Tell the WebSocket handler we're ready
+      if (ws) ws.send(JSON.stringify({type: 'llm_configured'}));
+      // Clear the bootstrap UI
+      setTimeout(function() {
+        var msgs = document.getElementById('messages');
+        if (msgs) msgs.innerHTML = '';
+      }, 500);
+    } else {
+      if (status) status.textContent = data.error || 'Failed';
+      if (btn) btn.disabled = false;
+    }
+  }).catch(function(err) {
+    if (status) status.textContent = 'Error: ' + err.message;
+    if (btn) btn.disabled = false;
+  });
 }
 
 function send() {

--- a/static/imp.css
+++ b/static/imp.css
@@ -106,6 +106,10 @@ body { font-family:-apple-system,BlinkMacSystemFont,"Segoe UI",Roboto,sans-serif
 .msg .body .thinking-block .thinking-content { padding:8px 12px; border-top:1px solid var(--border);
   font-size:12px; color:var(--muted); line-height:1.5; white-space:pre-wrap; }
 
+/* --- LLM bootstrap --- */
+.llm-bootstrap { max-width:420px; }
+.llm-bootstrap h3 { font-size:16px; color:var(--fg); }
+
 /* --- input area --- */
 #input-area { border-top:1px solid var(--border); padding:12px 24px; background:#010409; }
 #input-row { display:flex; gap:8px; }


### PR DESCRIPTION
## Summary

Closes #198

- Detects if no Claude access is available before starting the setup agent
- Shows a non-LLM UI (simple HTML form) to pick and configure an alternative backend (e.g. Kimi K2 via OpenRouter)
- Setup agent now honors the `llm` config block from `.imp/config.json`, same as the Foreman agent

## Changes

- **server/setup_agent.py**: Added `has_llm_access()` helper; setup agent now reads LLM config and passes SDK kwargs
- **server/chat_ws.py**: Before starting setup, checks LLM availability. Sends `need_llm_config` WS message if none found
- **server/render_route.py**: Added `GET /api/llm-presets` and `POST /api/llm-bootstrap` endpoints
- **static/imp-chat.js**: Frontend handler for `need_llm_config` — shows preset picker and API key input
- **static/imp.css**: Minor styling for the bootstrap form

## Test plan

- [x] Start Imp without `ANTHROPIC_API_KEY` and without Claude CLI -- should show LLM backend picker
- [x] Select Kimi K2 preset, paste OpenRouter key -- should save config and proceed to setup
- [ ] Start Imp with `ANTHROPIC_API_KEY` set -- should skip bootstrap and go straight to setup as before
- [x] Verify `GET /api/llm-status` returns correct `has_access` boolean

Generated with Claude Code