### PR TITLE
Drop line-number columns for non-diff previews

### DIFF
--- a/server/foreman_agent.py
+++ b/server/foreman_agent.py
@@ -276,7 +276,9 @@ def _make_security_hook(confirm: Optional[ConfirmFn] = None):
             # Writes need user confirmation
             if confirm:
                 desc = tool_input.get("description", command[:80])
-                approved = await confirm(tool_name, desc, command)
+                cmd_lines = command.splitlines() or [command]
+                preview = "@@ -0,0 +1," + str(len(cmd_lines)) + " @@\n" + "\n".join("+" + l for l in cmd_lines)
+                approved = await confirm(tool_name, desc, preview)
                 if not approved:
                     return PermissionResultDeny(behavior="deny", message="User rejected", interrupt=False)
             return PermissionResultAllow(behavior="allow")

--- a/static/imp-chat.js
+++ b/static/imp-chat.js
@@ -8,21 +8,13 @@ function renderDiff(text) {
   var lines = text.split('\n');
   var rows = '';
   var oldN = 0, newN = 0;
-  var hasHeader = lines.some(function(l) { return l.startsWith('@@'); });
-  var hasPlus = lines.some(function(l) { return l.startsWith('+'); });
-  var hasMinus = lines.some(function(l) { return l.startsWith('-'); });
-  // Plain text (Bash command, generic tool input): no diff markers — no line numbers
-  var isPlain = !hasHeader && !hasPlus && !hasMinus;
-  // New file: + lines but no - lines (Write of new file) — single line-number column
-  var isNewFile = !isPlain && hasPlus && !hasMinus;
-  var cols = isPlain ? 1 : (isNewFile ? 2 : 3);
+  // Detect new-file diffs (all content lines are +, no - lines)
+  var isNewFile = lines.some(function(l) { return l.startsWith('+'); }) &&
+                  !lines.some(function(l) { return l.startsWith('-'); });
+  var cols = isNewFile ? 2 : 3; // single line-number col for new files
   for (var i = 0; i < lines.length; i++) {
     var line = lines[i];
     var bg, sign, lOld, lNew, content;
-    if (isPlain) {
-      rows += '<tr><td style="padding:0 6px;font-family:monospace;font-size:11px;white-space:pre-wrap;">' + line + '</td></tr>';
-      continue;
-    }
     if (line.startsWith('@@')) {
       var m = line.match(/@@ -(\d+)/);
       if (m) { oldN = parseInt(m[1]) - 1; }

--- a/static/imp-chat.js
+++ b/static/imp-chat.js
@@ -8,13 +8,21 @@ function renderDiff(text) {
   var lines = text.split('\n');
   var rows = '';
   var oldN = 0, newN = 0;
-  // Detect new-file diffs (all content lines are +, no - lines)
-  var isNewFile = lines.some(function(l) { return l.startsWith('+'); }) &&
-                  !lines.some(function(l) { return l.startsWith('-'); });
-  var cols = isNewFile ? 2 : 3; // single line-number col for new files
+  var hasHeader = lines.some(function(l) { return l.startsWith('@@'); });
+  var hasPlus = lines.some(function(l) { return l.startsWith('+'); });
+  var hasMinus = lines.some(function(l) { return l.startsWith('-'); });
+  // Plain text (Bash command, generic tool input): no diff markers — no line numbers
+  var isPlain = !hasHeader && !hasPlus && !hasMinus;
+  // New file: + lines but no - lines (Write of new file) — single line-number column
+  var isNewFile = !isPlain && hasPlus && !hasMinus;
+  var cols = isPlain ? 1 : (isNewFile ? 2 : 3);
   for (var i = 0; i < lines.length; i++) {
     var line = lines[i];
     var bg, sign, lOld, lNew, content;
+    if (isPlain) {
+      rows += '<tr><td style="padding:0 6px;font-family:monospace;font-size:11px;white-space:pre-wrap;">' + line + '</td></tr>';
+      continue;
+    }
     if (line.startsWith('@@')) {
       var m = line.match(/@@ -(\d+)/);
       if (m) { oldN = parseInt(m[1]) - 1; }


### PR DESCRIPTION
## Summary
- `renderDiff()` is used for every confirmation preview ([imp-chat.js:306](static/imp-chat.js#L306)) — Bash, Write, Edit, generic tools — but only Edit and Write-of-new-file actually contain diff markers
- Plain-text previews (Bash command, `str(tool_input)` for generic tools) fell into the "context line" branch and rendered with two redundant line-number columns
- Detect "no `@@` header AND no `+`/`-` prefix" → render as a single content column, no line numbers; diff and new-file paths are unchanged

Closes #200

## Test plan
- [ ] Approve a Bash command with a multi-line `command` value — should render as plain text with no line numbers
- [ ] Approve a Write of a new file (e.g. via `make_tool.py`) — should still render with a single line-number column
- [ ] Approve an Edit on an existing file — should still render with old/new line-number columns and `+`/`-` markers

🤖 Generated with [Claude Code](https://claude.com/claude-code)